### PR TITLE
Fix windows compilation issues

### DIFF
--- a/inkcpp_compiler/binary_emitter.cpp
+++ b/inkcpp_compiler/binary_emitter.cpp
@@ -16,7 +16,7 @@ namespace ink::compiler::internal
 	using std::tuple;
 
 	char* strtok_s(char * s, const char * sep, char** context) {
-#ifdef WIN32
+#if defined(_WIN32) || defined(_WIN64)
 		return ::strtok_s(s, sep, context);
 #else
 		if (
@@ -268,7 +268,7 @@ namespace ink::compiler::internal
 			while (token != nullptr)
 			{
 				// Number
-				if (std::isdigit(token[0]))
+				if (isdigit(token[0]))
 				{
 					// Check if we have a nop registered at that index
 					int index = atoi(token);


### PR DESCRIPTION
Windows didn't want to compile anymore on my end.
Two tiny fixes had to be made to get it working again:
- Changing std::isdigit() to isdigit() as described here:


- Checking if WIN32 and/or WIN64 is defined for some reason? 🤔 Solely checking for WIN32 doesn't seem to work for Github Actions. Maybe there's a better way to do this?
There's seems to be the possibility to check for `#ifndef HAVE_STRTOK_R` which might be more descriptive?

Cheers!
