### PR TITLE
Get INK Global Variables from C++

### DIFF
--- a/inkcpp/collections/restorable.h
+++ b/inkcpp/collections/restorable.h
@@ -287,30 +287,13 @@ namespace ink::runtime::internal
 
 		// Reverse find
 		template<typename Predicate>
-		const ElementType* reverse_find(Predicate predicate) const
-		{
-			if (_pos == 0) {
-				return nullptr;
-			}
+		ElementType* reverse_find(Predicate predicate) {
+			return reverse_find_impl(predicate);
+		}
 
-			// Start at the end
-			size_t i = _pos;
-			do
-			{
-				// Move back one element
-				i--;
-
-				// Run callback
-				if (predicate(_buffer[i]))
-					return &_buffer[i];
-
-				// Jump over saved data
-				if (i == _save)
-					i = _jump;
-
-			} while (i > 0);
-
-			return nullptr;
+		template<typename Predicate>
+		const ElementType* reverse_find(Predicate predicate) const {
+			return reverse_find_impl(predicate);
 		}
 
 		template<typename IsNullPredicate>
@@ -347,6 +330,33 @@ namespace ink::runtime::internal
 		virtual void overflow(ElementType*& buffer, size_t& size) { throw 0; /* TODO: What to do here? Throw something more useful? */ }
 
 	private:
+		template<typename Predicate>
+		ElementType* reverse_find_impl(Predicate predicate) const
+		{
+			if (_pos == 0) {
+				return nullptr;
+			}
+
+			// Start at the end
+			size_t i = _pos;
+			do
+			{
+				// Move back one element
+				i--;
+
+				// Run callback
+				if (predicate(_buffer[i]))
+					return &_buffer[i];
+
+				// Jump over saved data
+				if (i == _save)
+					i = _jump;
+
+			} while (i > 0);
+
+			return nullptr;
+		}
+
 		// Data buffer. Collection is stored here
 		ElementType* _buffer;
 

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -72,28 +72,40 @@ namespace ink::runtime::internal
 		return _variables.get(name);
 	}
 
-	uint32_t* globals_impl::getUInt(hash_t name) const {
-		value* v = _variables.get(name);
-		return v && v->get_data_type() == data_type::uint32
-			? v->as_uint_ptr()
+	template<auto (value::*FN)()>
+	auto fetchVariable(auto stack, hash_t name, data_type type) {
+		auto v = stack.get(name);
+		return v && v->get_data_type() == type
+			? (v->*FN)()
 			: nullptr;
 	}
 
-	int32_t* globals_impl::getInt(hash_t name) const {
-		value* v = _variables.get(name);
-		return v && v->get_data_type() == data_type::int32
-			? v->as_int_ptr()
-			: nullptr;
+	const uint32_t* globals_impl::getUInt(hash_t name) const {
+		return fetchVariable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
+	}
+	uint32_t* globals_impl::getUInt(hash_t name) {
+		return fetchVariable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
 	}
 
-	float* globals_impl::getFloat(hash_t name) const {
-		value* v =  _variables.get(name);
-		return v && v->get_data_type() == data_type::float32
-			? v->as_float_ptr()
-			: nullptr;
+	const int32_t* globals_impl::getInt(hash_t name) const {
+		return fetchVariable<&value::as_int_ptr>(_variables, name, data_type::int32);
+	}
+	int32_t* globals_impl::getInt(hash_t name) {
+		return fetchVariable<&value::as_int_ptr>(_variables, name, data_type::int32);
 	}
 
-	char* globals_impl::getStr(hash_t name) const {
+	const float* globals_impl::getFloat(hash_t name) const {
+		return fetchVariable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	}
+	float* globals_impl::getFloat(hash_t name) {
+		return fetchVariable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	}
+
+	char* globals_impl::getStr(hash_t name) {
+		// TODO: add string support
+		throw ink_exception("String handling is not supported yet!");
+	}
+	const char* globals_impl::getStr(hash_t name) const {
 		// TODO: add string support
 		throw ink_exception("String handling is not supported yet!");
 	}

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -73,39 +73,39 @@ namespace ink::runtime::internal
 	}
 
 	template<auto (value::*FN)()>
-	auto fetchVariable(auto stack, hash_t name, data_type type) {
+	auto fetch_variable(auto stack, hash_t name, data_type type) {
 		auto v = stack.get(name);
 		return v && v->get_data_type() == type
 			? (v->*FN)()
 			: nullptr;
 	}
 
-	const uint32_t* globals_impl::getUInt(hash_t name) const {
-		return fetchVariable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
+	const uint32_t* globals_impl::get_uint(hash_t name) const {
+		return fetch_variable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
 	}
-	uint32_t* globals_impl::getUInt(hash_t name) {
-		return fetchVariable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
-	}
-
-	const int32_t* globals_impl::getInt(hash_t name) const {
-		return fetchVariable<&value::as_int_ptr>(_variables, name, data_type::int32);
-	}
-	int32_t* globals_impl::getInt(hash_t name) {
-		return fetchVariable<&value::as_int_ptr>(_variables, name, data_type::int32);
+	uint32_t* globals_impl::get_uint(hash_t name) {
+		return fetch_variable<&value::as_uint_ptr>(_variables, name, data_type::uint32);
 	}
 
-	const float* globals_impl::getFloat(hash_t name) const {
-		return fetchVariable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	const int32_t* globals_impl::get_int(hash_t name) const {
+		return fetch_variable<&value::as_int_ptr>(_variables, name, data_type::int32);
 	}
-	float* globals_impl::getFloat(hash_t name) {
-		return fetchVariable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	int32_t* globals_impl::get_int(hash_t name) {
+		return fetch_variable<&value::as_int_ptr>(_variables, name, data_type::int32);
 	}
 
-	char* globals_impl::getStr(hash_t name) {
+	const float* globals_impl::get_float(hash_t name) const {
+		return fetch_variable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	}
+	float* globals_impl::get_float(hash_t name) {
+		return fetch_variable<&value::as_float_ptr>(_variables, name, data_type::float32);
+	}
+
+	char* globals_impl::get_str(hash_t name) {
 		// TODO: add string support
 		throw ink_exception("String handling is not supported yet!");
 	}
-	const char* globals_impl::getStr(hash_t name) const {
+	const char* globals_impl::get_str(hash_t name) const {
 		// TODO: add string support
 		throw ink_exception("String handling is not supported yet!");
 	}

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -68,6 +68,37 @@ namespace ink::runtime::internal
 		return _variables.get(name);
 	}
 
+	value* globals_impl::get_variable(hash_t name) {
+		return _variables.get(name);
+	}
+
+	uint32_t* globals_impl::getUInt(hash_t name) const {
+		value* v = _variables.get(name);
+		return v && v->get_data_type() == data_type::uint32
+			? v->as_uint_ptr()
+			: nullptr;
+	}
+
+	int32_t* globals_impl::getInt(hash_t name) const {
+		value* v = _variables.get(name);
+		return v && v->get_data_type() == data_type::int32
+			? v->as_int_ptr()
+			: nullptr;
+	}
+
+	float* globals_impl::getFloat(hash_t name) const {
+		value* v =  _variables.get(name);
+		return v && v->get_data_type() == data_type::float32
+			? v->as_float_ptr()
+			: nullptr;
+	}
+
+	char* globals_impl::getStr(hash_t name) const {
+		// TODO: add string support
+		throw ink_exception("String handling is not supported yet!");
+	}
+
+
 	void globals_impl::initialize_globals(runner_impl* run)
 	{
 		// If no way to move there, then there are no globals.

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -20,13 +20,17 @@ namespace ink::runtime::internal
 		virtual ~globals_impl() { }
 
 	protected:
-		uint32_t* getUInt(hash_t name) const override;
+		const uint32_t* getUInt(hash_t name) const override;
+		uint32_t* getUInt(hash_t name) override;
 
-		int32_t* getInt(hash_t name) const override;
+	  	const int32_t* getInt(hash_t name) const override;
+	  	int32_t* getInt(hash_t name) override;
 
-		float* getFloat(hash_t name) const override;
+		const float* getFloat(hash_t name) const override;
+		float* getFloat(hash_t name) override;
 
-		char* getStr(hash_t name) const override;
+		const char* getStr(hash_t name) const override;
+		char* getStr(hash_t name) override;
 
 	public:
 		// Records a visit to a container
@@ -89,7 +93,7 @@ namespace ink::runtime::internal
 		// Global variables (TODO: Max 50?)
 		//  Implemented as a stack (slow lookup) because it has save/restore functionality.
 		//  If I could create an avl tree with save/restore, that'd be great but seems super complex.
-		mutable internal::stack<50> _variables;
+		internal::stack<50> _variables;
 		bool _globals_initialized;
 	};
 }

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -20,17 +20,17 @@ namespace ink::runtime::internal
 		virtual ~globals_impl() { }
 
 	protected:
-		const uint32_t* getUInt(hash_t name) const override;
-		uint32_t* getUInt(hash_t name) override;
+		const uint32_t* get_uint(hash_t name) const override;
+		uint32_t* get_uint(hash_t name) override;
 
-	  	const int32_t* getInt(hash_t name) const override;
-	  	int32_t* getInt(hash_t name) override;
+	  	const int32_t* get_int(hash_t name) const override;
+	  	int32_t* get_int(hash_t name) override;
 
-		const float* getFloat(hash_t name) const override;
-		float* getFloat(hash_t name) override;
+		const float* get_float(hash_t name) const override;
+		float* get_float(hash_t name) override;
 
-		const char* getStr(hash_t name) const override;
-		char* getStr(hash_t name) override;
+		const char* get_str(hash_t name) const override;
+		char* get_str(hash_t name) override;
 
 	public:
 		// Records a visit to a container

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -19,7 +19,14 @@ namespace ink::runtime::internal
 		globals_impl(const story_impl*);
 		virtual ~globals_impl() { }
 
-		virtual void dummy() override { }
+	protected:
+		uint32_t* getUInt(hash_t name) const override;
+
+		int32_t* getInt(hash_t name) const override;
+
+		float* getFloat(hash_t name) const override;
+
+		char* getStr(hash_t name) const override;
 
 	public:
 		// Records a visit to a container
@@ -37,6 +44,7 @@ namespace ink::runtime::internal
 
 		// gets a global variable
 		const value* get_variable(hash_t name) const;
+		value* get_variable(hash_t name);
 
 		// checks if globals are initialized
 		bool are_globals_initialized() const { return _globals_initialized; }
@@ -46,7 +54,7 @@ namespace ink::runtime::internal
 
 		// gets the allocated string table
 		inline string_table& strings() { return _strings; }
-		
+
 		// run garbage collection
 		void gc();
 
@@ -54,10 +62,11 @@ namespace ink::runtime::internal
 		void save();
 		void restore();
 		void forget();
+
 	private:
 		// Store the number of containers. This is the length of most of our lists
 		const uint32_t _num_containers;
-		
+
 		// Visit count array
 		internal::allocated_restorable_array<uint32_t> _visit_counts;
 
@@ -80,7 +89,7 @@ namespace ink::runtime::internal
 		// Global variables (TODO: Max 50?)
 		//  Implemented as a stack (slow lookup) because it has save/restore functionality.
 		//  If I could create an avl tree with save/restore, that'd be great but seems super complex.
-		internal::stack<50> _variables;
+		mutable internal::stack<50> _variables;
 		bool _globals_initialized;
 	};
 }

--- a/inkcpp/include/globals.h
+++ b/inkcpp/include/globals.h
@@ -22,45 +22,63 @@ namespace ink::runtime
 		 */
 		template<typename T>
 		T* get(const char* name) {
-			return get_impl<T>(hash_string(name));
+			static_assert(
+					internal::always_false<T>::value,
+					"Requested Type is not supported");
 		}
 		template<typename T>
 		const T* get(const char* name) const {
-			return get_impl<T>(hash_string(name));
+			static_assert(
+					internal::always_false<T>::value,
+					"Requested Type is not supported");
 		}
 
 		virtual ~globals_interface() = default;
 
 	protected:
-		template<typename T>
-		T* get_impl(hash_t name) const {
-			static_assert(
-					internal::always_false<T>::value,
-					"Requested Type is not supported");
-		}
-		virtual uint32_t* getUInt(hash_t name) const = 0;
-		virtual int32_t* getInt(hash_t name) const = 0;
-		virtual float* getFloat(hash_t name) const = 0;
-		virtual char* getStr(hash_t name) const = 0;
+		virtual const uint32_t* getUInt(hash_t name) const = 0;
+		virtual uint32_t* getUInt(hash_t name) = 0;
+		virtual const int32_t* getInt(hash_t name) const = 0;
+		virtual int32_t* getInt(hash_t name) = 0;
+		virtual const float* getFloat(hash_t name) const = 0;
+		virtual float* getFloat(hash_t name) = 0;
+		virtual const char* getStr(hash_t name) const = 0;
+		virtual char* getStr(hash_t name) = 0;
 	};
 
 	template<>
-	inline uint32_t* globals_interface::get_impl<uint32_t>(hash_t name) const {
-		return getUInt(name);
+	inline const uint32_t* globals_interface::get<uint32_t>(const char* name) const {
+		return getUInt(hash_string(name));
+	}
+	template<>
+	inline uint32_t* globals_interface::get<uint32_t>(const char* name) {
+		return getUInt(hash_string(name));
 	}
 
 	template<>
-	inline int32_t* globals_interface::get_impl<int32_t>(hash_t name) const {
-		return getInt(name);
+	inline const int32_t* globals_interface::get<int32_t>(const char* name) const {
+		return getInt(hash_string(name));
+	}
+	template<>
+	inline int32_t* globals_interface::get<int32_t>(const char* name) {
+		return getInt(hash_string(name));
 	}
 
 	template<>
-	inline float* globals_interface::get_impl<float>(hash_t name) const {
-		return getFloat(name);
+	inline const float* globals_interface::get<float>(const char* name) const {
+		return getFloat(hash_string(name));
+	}
+	template<>
+	inline float* globals_interface::get<float>(const char* name) {
+		return getFloat(hash_string(name));
 	}
 
 	template<>
-	inline char* globals_interface::get_impl<char>(hash_t name) const {
-		return getStr(name);
+	inline const char* globals_interface::get<char>(const char* name) const {
+		return getStr(hash_string(name));
+	}
+	template<>
+	inline char* globals_interface::get<char>(const char* name) {
+		return getStr(hash_string(name));
 	}
 }

--- a/inkcpp/include/globals.h
+++ b/inkcpp/include/globals.h
@@ -16,36 +16,51 @@ namespace ink::runtime
 		 * @brief Access global variable of Ink runner.
 		 * @param name name of variable, as defined in InkScript
 		 * @tparam T c++ type of variable
+		 * @return nullptr if variable with this name don't exist or
+		 *                 the type differs.
+		 * @return pointer to variable
 		 */
 		template<typename T>
-		T* get(const char* name);
+		T* get(const char* name) {
+			return get_impl<T>(hash_string(name));
+		}
+		template<typename T>
+		const T* get(const char* name) const {
+			return get_impl<T>(hash_string(name));
+		}
 
 		virtual ~globals_interface() = default;
 
 	protected:
-		virtual uint32_t* getUInt(const char* name) = 0;
-		virtual int32_t* getInt(const char* name) = 0;
-		virtual float* getFloat(const char* name) = 0;
-		virtual char* getStr(const char* name) = 0;
+		template<typename T>
+		T* get_impl(hash_t name) const {
+			static_assert(
+					internal::always_false<T>::value,
+					"Requested Type is not supported");
+		}
+		virtual uint32_t* getUInt(hash_t name) const = 0;
+		virtual int32_t* getInt(hash_t name) const = 0;
+		virtual float* getFloat(hash_t name) const = 0;
+		virtual char* getStr(hash_t name) const = 0;
 	};
 
 	template<>
-	uint32_t* globals_interface::get<uint32_t>(const char* name) {
+	inline uint32_t* globals_interface::get_impl<uint32_t>(hash_t name) const {
 		return getUInt(name);
 	}
 
 	template<>
-	int32_t* globals_interface::get<int32_t>(const char* name) {
+	inline int32_t* globals_interface::get_impl<int32_t>(hash_t name) const {
 		return getInt(name);
 	}
 
 	template<>
-	float* globals_interface::get<float>(const char* name) {
+	inline float* globals_interface::get_impl<float>(hash_t name) const {
 		return getFloat(name);
 	}
 
 	template<>
-	char* globals_interface::get<char>(const char* name) {
+	inline char* globals_interface::get_impl<char>(hash_t name) const {
 		return getStr(name);
 	}
 }

--- a/inkcpp/include/globals.h
+++ b/inkcpp/include/globals.h
@@ -36,49 +36,49 @@ namespace ink::runtime
 		virtual ~globals_interface() = default;
 
 	protected:
-		virtual const uint32_t* getUInt(hash_t name) const = 0;
-		virtual uint32_t* getUInt(hash_t name) = 0;
-		virtual const int32_t* getInt(hash_t name) const = 0;
-		virtual int32_t* getInt(hash_t name) = 0;
-		virtual const float* getFloat(hash_t name) const = 0;
-		virtual float* getFloat(hash_t name) = 0;
-		virtual const char* getStr(hash_t name) const = 0;
-		virtual char* getStr(hash_t name) = 0;
+		virtual const uint32_t* ge_uitnt(hash_t name) const = 0;
+		virtual uint32_t* get_uint(hash_t name) = 0;
+		virtual const int32_t* get_int(hash_t name) const = 0;
+		virtual int32_t* get_int(hash_t name) = 0;
+		virtual const float* get_float(hash_t name) const = 0;
+		virtual float* get_float(hash_t name) = 0;
+		virtual const char* get_str(hash_t name) const = 0;
+		virtual char* get_str(hash_t name) = 0;
 	};
 
 	template<>
 	inline const uint32_t* globals_interface::get<uint32_t>(const char* name) const {
-		return getUInt(hash_string(name));
+		return get_uint(hash_string(name));
 	}
 	template<>
 	inline uint32_t* globals_interface::get<uint32_t>(const char* name) {
-		return getUInt(hash_string(name));
+		return get_uint(hash_string(name));
 	}
 
 	template<>
 	inline const int32_t* globals_interface::get<int32_t>(const char* name) const {
-		return getInt(hash_string(name));
+		return get_int(hash_string(name));
 	}
 	template<>
 	inline int32_t* globals_interface::get<int32_t>(const char* name) {
-		return getInt(hash_string(name));
+		return get_int(hash_string(name));
 	}
 
 	template<>
 	inline const float* globals_interface::get<float>(const char* name) const {
-		return getFloat(hash_string(name));
+		return get_float(hash_string(name));
 	}
 	template<>
 	inline float* globals_interface::get<float>(const char* name) {
-		return getFloat(hash_string(name));
+		return get_float(hash_string(name));
 	}
 
 	template<>
 	inline const char* globals_interface::get<char>(const char* name) const {
-		return getStr(hash_string(name));
+		return get_str(hash_string(name));
 	}
 	template<>
 	inline char* globals_interface::get<char>(const char* name) {
-		return getStr(hash_string(name));
+		return get_str(hash_string(name));
 	}
 }

--- a/inkcpp/include/globals.h
+++ b/inkcpp/include/globals.h
@@ -11,8 +11,41 @@ namespace ink::runtime
 	class globals_interface
 	{
 	public:
-		// No public interface yet
-		virtual void dummy() = 0;
+
+		/**
+		 * @brief Access global variable of Ink runner.
+		 * @param name name of variable, as defined in InkScript
+		 * @tparam T c++ type of variable
+		 */
+		template<typename T>
+		T* get(const char* name);
+
 		virtual ~globals_interface() = default;
+
+	protected:
+		virtual uint32_t* getUInt(const char* name) = 0;
+		virtual int32_t* getInt(const char* name) = 0;
+		virtual float* getFloat(const char* name) = 0;
+		virtual char* getStr(const char* name) = 0;
 	};
+
+	template<>
+	uint32_t* globals_interface::get<uint32_t>(const char* name) {
+		return getUInt(name);
+	}
+
+	template<>
+	int32_t* globals_interface::get<int32_t>(const char* name) {
+		return getInt(name);
+	}
+
+	template<>
+	float* globals_interface::get<float>(const char* name) {
+		return getFloat(name);
+	}
+
+	template<>
+	char* globals_interface::get<char>(const char* name) {
+		return getStr(name);
+	}
 }

--- a/inkcpp/stack.h
+++ b/inkcpp/stack.h
@@ -36,6 +36,7 @@ namespace ink
 
 				// Gets an existing value, or nullptr
 				const value* get(hash_t name) const;
+				value* get(hash_t name);
 
 				// pushes a new frame onto the stack
 				void push_frame(offset_t return_to, frame_type type);

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -96,9 +96,12 @@ namespace ink
 
 				// == Getters ==
 				int as_int() const { return _first.integer_value; }
+				int* as_int_ptr() { return &_first.integer_value; }
 				float as_float() const { return _first.float_value; }
+				float* as_float_ptr() { return &_first.float_value; }
 				uint32_t as_divert() const { return _first.uint_value; }
 				uint32_t as_thread_id() const { return _first.uint_value; }
+				uint32_t* as_uint_ptr() { return &_first.uint_value; }
 				// TODO: String access?
 
 				template<typename T>

--- a/inkcpp_test/CMakeLists.txt
+++ b/inkcpp_test/CMakeLists.txt
@@ -4,6 +4,16 @@ add_executable(inkcpp_test catch.hpp Main.cpp
     Stack.cpp
     Callstack.cpp
     Restorable.cpp
+	Globals.cpp
     )
 
 target_link_libraries(inkcpp_test PUBLIC inkcpp)
+
+set (source "${CMAKE_CURRENT_SOURCE_DIR}/ink")
+set (destination "${CMAKE_CURRENT_BINARY_DIR}/ink")
+add_custom_command(
+    TARGET inkcpp_test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${source} ${destination}
+    DEPENDS ${destination}
+    COMMENT "symbolic link resources folder from ${source} => ${destination}"
+)

--- a/inkcpp_test/Globals.cpp
+++ b/inkcpp_test/Globals.cpp
@@ -1,0 +1,50 @@
+#include "catch.hpp"
+
+#include <story.h>
+#include <globals.h>
+#include <runner.h>
+
+using namespace ink::runtime;
+
+SCENARIO("run story with global variable", "[global variables]")
+{
+	GIVEN ("a story with global variables")
+	{
+		story* ink = story::from_file("ink/GlobalStory.bin");
+
+
+		WHEN( "just runs")
+		{
+			globals globStore = ink->new_globals();
+			runner thread = ink->new_runner(globStore);
+			THEN("variables should contain values as in inkScript")
+			{
+				REQUIRE(thread->getall() == "My name is Jean Passepartout, but my friend's call me Jackie. I'm 23 years old.\n");
+				REQUIRE(*globStore->get<int32_t>("age") == 23);
+			}
+		}
+		WHEN ("edit number")
+		{
+			globals globStore = ink->new_globals();
+			runner thread = ink->new_runner(globStore);
+			*globStore->get<int32_t>("age") = 30;
+			THEN("variable should contain new value")
+			{
+				REQUIRE(thread->getall() == "My name is Jean Passepartout, but my friend's call me Jackie. I'm 30 years old.\n");
+				REQUIRE(*globStore->get<int32_t>("age") == 30);
+			}
+		}
+		WHEN ("name or type not exist")
+		{
+			globals globStore = ink->new_globals();
+			runner thread = ink->new_runner(globStore);
+			auto wrongType = globStore->get<uint32_t>("age");
+			auto notExistingName = globStore->get<int32_t>("foo");
+			THEN("should return nullptr")
+			{
+				REQUIRE(wrongType == nullptr);
+				REQUIRE(notExistingName == nullptr);
+			}
+		}
+	}
+}

--- a/inkcpp_test/ink/GlobalStory.ink
+++ b/inkcpp_test/ink/GlobalStory.ink
@@ -1,0 +1,6 @@
+// from official ink tutorial
+
+VAR friendly_name_of_player = "Jackie"
+VAR age = 23
+
+My name is Jean Passepartout, but my friend's call me {friendly_name_of_player}. I'm {age} years old. 


### PR DESCRIPTION
Enables reading and writing of INK global variables from C++ code.

Use template function in `class globals` to access them.

```cpp
class {
	// @brief access global variable from ink story
	// @param name name of variable (as defined in Ink Script)
	// @return nullptr if there is no such variable
	// @return pointer to variable
	template<typename T>
	T* get_global(const char* name);
}
```
