### PR TITLE
Update README for setup on non-Unreal projects and add error check

### DIFF
--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -32,6 +32,11 @@ namespace ink::runtime::internal
 		using namespace std;
 
 		ifstream ifs(filename, ios::binary | ios::ate);
+
+		if (!ifs.is_open()) {
+			throw ink_exception("Failed to open file!");
+		}
+
 		ifstream::pos_type pos = ifs.tellg();
 		size_t length = (size_t)pos;
 		unsigned char* data = new unsigned char[length];

--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -34,7 +34,7 @@ namespace ink::runtime::internal
 		ifstream ifs(filename, ios::binary | ios::ate);
 
 		if (!ifs.is_open()) {
-			throw ink_exception("Failed to open file!");
+			throw ink_exception("Failed to open file: " + std::string(filename));
 		}
 
 		ifstream::pos_type pos = ifs.tellg();


### PR DESCRIPTION
This PR updates the README file with instructions for building/including in a non-Unreal C++ project (it's currently a bit of a pain and took me a while to figure out). It also updates the example and provides some troubleshooting steps.

I also included an error check in the STL file read `ifstream` mode to ensure the file was opened properly. It earlier failed on the parsing step and produced an endianness error; it now properly reports the error to the user. I included this because it also tripped me up for a bit.

The test file passes when I run it with `-C Release`, but not `-C Debug` (standing issue, not caused by my changes). 

Let me know if I should change or add anything!