### PR TITLE
Fix MSVC Debug Compiler complain

### DIFF
--- a/inkcpp/string_utils.h
+++ b/inkcpp/string_utils.h
@@ -130,10 +130,8 @@ namespace ink::runtime::internal {
 				if (LEADING_SPACES && (src[0] == ' ' || src[0] == '\n')) { continue; }
 			}
 			else if(src[-1] == '\n' && (src[0] == ' ' || src[0] == '\n')) { continue;}
-			else if(src[0] == ' ' &&
-					( (src+1 == end && TAILING_SPACES)
-					 || src[1] == ' '
-					 || src[1] == '\n')) {
+			else if ( src[0] == ' ' && ( ( src + 1 == end && TAILING_SPACES ) || (( src + 1 != end ) && ( src[1] == ' ' || src[1] == '\n' ) ) ) )
+			{
 				continue;
 			}
 			else if(src[0] == '\n' && dst != begin && dst[-1] == '\n') { continue; }


### PR DESCRIPTION
When deleting tailing Spaces, it may happen, that we look at the termination byte ('\0'). MSVCs implementation of the String Iterator exits the program when that happens with an out-of-bounds error. To avoid this, we check if string remaining before doing the look ahead.

Fixes #41 