### PR TITLE
Add Snapshots for story state (save/load)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ The big things we're missing right now are:
 
 * Fallback functions for externals.
 * Variable observers
-* Lists and whatever cool, crazy stuff Ink has been adding recently.
-* Robust tests using ink-proof.
 
 ## Dependencies
 The compiler depends on Nlohmann's JSON library and the C++ STL.

--- a/inkcpp/CMakeLists.txt
+++ b/inkcpp/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND SOURCES
     runner_impl.h runner_impl.cpp
     simple_restorable_stack.h stack.h stack.cpp
     story_impl.h story_impl.cpp
+	snapshot_impl.h snapshot_impl.cpp snapshot_interface.h
     story_ptr.cpp
     system.cpp
     value.h value.cpp

--- a/inkcpp/array.h
+++ b/inkcpp/array.h
@@ -153,7 +153,7 @@ namespace ink::runtime::internal
 
 		// snapshot interface
 		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 	protected:
 		inline T* buffer() { return _array; }
@@ -195,6 +195,22 @@ namespace ink::runtime::internal
 			ptr = snap_write(ptr, _temp[i], data);
 		}
 		return ptr - data;
+	}
+
+	template<typename T>
+	inline const unsigned char* basic_restorable_array<T>::snap_load(const unsigned char* data, const loader& loader)
+	{
+		auto ptr = data;
+		ptr = snap_read(ptr, _saved);
+		ptr = snap_read(ptr, _capacity);
+		T null;
+		ptr = snap_read(ptr, null);
+		inkAssert(null == _null, "null value is different to snapshot!");
+		for(size_t i = 0; i < _capacity; ++i) {
+			ptr = snap_read(ptr, _array[i]);
+			ptr = snap_read(ptr, _temp[i]);
+		}
+		return ptr;
 	}
 
 	template<typename T>

--- a/inkcpp/avl_array.h
+++ b/inkcpp/avl_array.h
@@ -87,11 +87,18 @@ class avl_array
     friend avl_array;         // avl_array may access index pointer
 
   public:
+
     // ctor
     tag_avl_array_iterator(if_t<Const, const avl_array*,avl_array*> instance = nullptr, size_type idx = 0U)
       : instance_(instance)
       , idx_(idx)
     { }
+
+  	template<bool C = Const, typename = ink::runtime::internal::enable_if_t<C>>
+  	tag_avl_array_iterator(const tag_avl_array_iterator<false>& itr)
+  	  : instance_(itr.instance_)
+  	  , idx_(itr.idx_)
+  	{}
 
     inline tag_avl_array_iterator& operator=(const tag_avl_array_iterator& other)
     {
@@ -117,6 +124,11 @@ class avl_array
     // access key
     inline const Key& key() const
     { return instance_->key_[idx_]; }
+
+	// returns unique number for each entry
+	// the numbers are unique as long no operation are executed
+	// on the avl
+  	inline size_t temp_identifier() const { return idx_; }
 
     // preincrement
     tag_avl_array_iterator& operator++()
@@ -193,12 +205,7 @@ public:
 
   inline const_iterator begin() const
   {
-    size_type i = INVALID_IDX;
-    if (root_ != INVALID_IDX) {
-      // find smallest element, it's the farthest node left from root
-      for (i = root_; child_[i].left != INVALID_IDX; i = child_[i].left);
-    }
-	return const_iterator(this, i);
+	return const_iterator(const_cast<avl_array&>(*this).begin());
   }
 
   inline iterator end()
@@ -339,6 +346,11 @@ public:
     }
     // key not found, return end() iterator
     return end();
+  }
+
+  inline const_iterator find(const key_type& key) const
+  {
+	  return const_iterator(const_cast<avl_array&>(*this).find(key));
   }
 
 

--- a/inkcpp/avl_array.h
+++ b/inkcpp/avl_array.h
@@ -41,6 +41,8 @@
 #ifndef _AVL_ARRAY_H_
 #define _AVL_ARRAY_H_
 
+#include "system.h"
+
 #include <cstdint>
 
 
@@ -73,16 +75,20 @@ class avl_array
   static const size_type INVALID_IDX = Size;
 
   // iterator class
-  typedef class tag_avl_array_iterator
+  template<bool Const>
+  class tag_avl_array_iterator
   {
-    avl_array*  instance_;    // array instance
+	template<bool Con, typename T1, typename T2>
+	using if_t = ink::runtime::internal::if_t<Con, T1, T2>;
+    if_t<Const, const avl_array*, avl_array*>
+		instance_;    		  // array instance
     size_type   idx_;         // actual node
 
     friend avl_array;         // avl_array may access index pointer
 
   public:
     // ctor
-    tag_avl_array_iterator(avl_array* instance = nullptr, size_type idx = 0U)
+    tag_avl_array_iterator(if_t<Const, const avl_array*,avl_array*> instance = nullptr, size_type idx = 0U)
       : instance_(instance)
       , idx_(idx)
     { }
@@ -101,15 +107,15 @@ class avl_array
     { return !(*this == rhs); }
 
     // dereference - access value
-    inline T& operator*() const
+    inline if_t<Const, const T&, T&> operator*() const
     { return val(); }
 
     // access value
-    inline T& val() const
+    inline if_t<Const, const T&, T&> val() const
     { return instance_->val_[idx_]; }
 
     // access key
-    inline Key& key() const
+    inline const Key& key() const
     { return instance_->key_[idx_]; }
 
     // preincrement
@@ -152,7 +158,7 @@ class avl_array
       ++(*this);
       return _copy;
     }
-  } avl_array_iterator;
+  };
 
 
 public:
@@ -163,7 +169,8 @@ public:
   typedef T&                  reference;
   typedef const T&            const_reference;
   typedef Key                 key_type;
-  typedef avl_array_iterator  iterator;
+  typedef tag_avl_array_iterator<false> iterator;
+  typedef tag_avl_array_iterator<true> const_iterator;
 
 
   // ctor
@@ -184,8 +191,23 @@ public:
     return iterator(this, i);
   }
 
+  inline const_iterator begin() const
+  {
+    size_type i = INVALID_IDX;
+    if (root_ != INVALID_IDX) {
+      // find smallest element, it's the farthest node left from root
+      for (i = root_; child_[i].left != INVALID_IDX; i = child_[i].left);
+    }
+	return const_iterator(this, i);
+  }
+
   inline iterator end()
   { return iterator(this, INVALID_IDX); }
+
+  inline const_iterator end() const
+  {
+	return const_iterator(this, INVALID_IDX);
+  }
 
 
   // capacity

--- a/inkcpp/avl_array.h
+++ b/inkcpp/avl_array.h
@@ -128,7 +128,7 @@ class avl_array
 	// returns unique number for each entry
 	// the numbers are unique as long no operation are executed
 	// on the avl
-  	inline size_t temp_identifier() const { return idx_; }
+  	inline size_t temp_identifier() const { return instance_->size() - idx_ - 1; }
 
     // preincrement
     tag_avl_array_iterator& operator++()

--- a/inkcpp/collections/restorable.cpp
+++ b/inkcpp/collections/restorable.cpp
@@ -2,16 +2,33 @@
 #include "../stack.h"
 
 namespace ink::runtime::internal {
+	unsigned char* snap_base(unsigned char* ptr, bool write, size_t pos, size_t jump, size_t save, size_t& max)
+	{
+		ptr = snapshot_interface::snap_write(ptr, pos,  write);
+		ptr = snapshot_interface::snap_write(ptr, jump, write);
+		ptr = snapshot_interface::snap_write(ptr, save, write);
+		max = pos;
+		if (jump > max) { max = jump; }
+		if (save > max) { max = save; }
+		return ptr;
+	}
+	const unsigned char* snap_load_base(const unsigned char* ptr, size_t& pos, size_t& jump, size_t& save, size_t& max)
+	{
+		ptr = snapshot_interface::snap_read(ptr, pos);
+		ptr = snapshot_interface::snap_read(ptr, jump);
+		ptr = snapshot_interface::snap_read(ptr, save);
+		max = pos;
+		if (jump > max) { max = jump; }
+		if (save > max) { max = save; }
+		return ptr;
+	}
+
 	template<>
 	size_t restorable<entry>::snap(unsigned char* data, const snapper& snapper) const
 	{
 		unsigned char* ptr = data;
-		ptr = snap_write(ptr, _pos, data);
-		ptr = snap_write(ptr, _jump, data);
-		ptr = snap_write(ptr, _save, data);
-		size_t max = _pos;
-		if (_jump > max) { max = _jump; }
-		if (_save > max) { max = _save; }
+		size_t max;
+		ptr = snap_base(ptr, data, _pos, _jump, _save, max);
 		for(size_t i = 0; i < max; ++i) {
 			ptr = snap_write(ptr, _buffer[i].name, data);
 			ptr += _buffer[i].data.snap(data ? ptr : nullptr, snapper);
@@ -22,12 +39,8 @@ namespace ink::runtime::internal {
 	size_t restorable<value>::snap(unsigned char* data, const snapper& snapper) const
 	{
 		unsigned char* ptr = data;
-		ptr = snap_write(ptr, _pos, data);
-		ptr = snap_write(ptr, _jump, data);
-		ptr = snap_write(ptr, _save, data);
-		size_t max = _pos;
-		if (_jump > max) { max = _jump; }
-		if (_save > max) { max = _save; }
+		size_t max;
+		ptr = snap_base(ptr, data, _pos, _jump, _save, max);
 		for(size_t i = 0; i < max; ++i) {
 			ptr += _buffer[i].snap(data ? ptr : nullptr, snapper);
 		}
@@ -37,15 +50,47 @@ namespace ink::runtime::internal {
 	size_t restorable<int>::snap(unsigned char* data, const snapper&) const
 	{
 		unsigned char* ptr = data;
-		ptr = snap_write(ptr, _pos, data);
-		ptr = snap_write(ptr, _jump, data);
-		ptr = snap_write(ptr, _save, data);
-		size_t max = _pos;
-		if (_jump > max) { max = _jump; }
-		if (_save > max) { max = _save; }
+		size_t max;
+		ptr = snap_base(ptr, data, _pos, _jump, _save, max);
 		for(size_t i = 0; i < max; ++i) {
 			ptr = snap_write(ptr, _buffer[i], data);
 		}
 		return ptr - data;
 	}
+
+	template<>
+	const unsigned char* restorable<entry>::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		size_t max;
+		ptr = snap_load_base(ptr, _pos, _jump, _save, max);
+		while(_size < max) { overflow(_buffer, _size); }
+		for(size_t i = 0; i < max; ++i) {
+			ptr = snap_read(ptr, _buffer[i].name);
+			ptr = _buffer[i].data.snap_load(ptr, loader);
+		}
+		return ptr;
+	}
+	template<>
+	const unsigned char* restorable<value>::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		size_t max;
+		ptr = snap_load_base(ptr, _pos, _jump, _save, max);
+		while(_size < max) { overflow(_buffer, _size); }
+		for(size_t i = 0; i < max; ++i) {
+			ptr = _buffer[i].snap_load(ptr, loader);
+		}
+		return ptr;
+	}
+	template<>
+	const unsigned char* restorable<int>::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		size_t max;
+		ptr = snap_load_base(ptr, _pos, _jump, _save, max);
+		while(_size < max) { overflow(_buffer, _size); }
+		for(size_t i = 0; i < max; ++i) {
+			ptr = snap_read(ptr, _buffer[i]);
+		}
+		return ptr;
+	}
+
 }

--- a/inkcpp/collections/restorable.cpp
+++ b/inkcpp/collections/restorable.cpp
@@ -1,0 +1,36 @@
+#include "restorable.h"
+#include "../stack.h"
+
+namespace ink::runtime::internal {
+	template<>
+	size_t restorable<entry>::snap(unsigned char* data, const snapper& snapper) const
+	{
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _pos, data);
+		ptr = snap_write(ptr, _jump, data);
+		ptr = snap_write(ptr, _save, data);
+		size_t max = _pos;
+		if (_jump > max) { max = _jump; }
+		if (_save > max) { max = _save; }
+		for(size_t i = 0; i < max; ++i) {
+			ptr = snap_write(ptr, _buffer[i].name, data);
+			ptr += _buffer[i].data.snap(data ? ptr : nullptr, snapper);
+		}
+		return ptr - data;
+	}
+	template<>
+	size_t restorable<value>::snap(unsigned char* data, const snapper& snapper) const
+	{
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _pos, data);
+		ptr = snap_write(ptr, _jump, data);
+		ptr = snap_write(ptr, _save, data);
+		size_t max = _pos;
+		if (_jump > max) { max = _jump; }
+		if (_save > max) { max = _save; }
+		for(size_t i = 0; i < max; ++i) {
+			ptr += _buffer[i].snap(data ? ptr : nullptr, snapper);
+		}
+		return ptr - data;
+	}
+}

--- a/inkcpp/collections/restorable.cpp
+++ b/inkcpp/collections/restorable.cpp
@@ -33,4 +33,19 @@ namespace ink::runtime::internal {
 		}
 		return ptr - data;
 	}
+	template<>
+	size_t restorable<int>::snap(unsigned char* data, const snapper&) const
+	{
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _pos, data);
+		ptr = snap_write(ptr, _jump, data);
+		ptr = snap_write(ptr, _save, data);
+		size_t max = _pos;
+		if (_jump > max) { max = _jump; }
+		if (_save > max) { max = _save; }
+		for(size_t i = 0; i < max; ++i) {
+			ptr = snap_write(ptr, _buffer[i], data);
+		}
+		return ptr - data;
+	}
 }

--- a/inkcpp/collections/restorable.h
+++ b/inkcpp/collections/restorable.h
@@ -334,7 +334,7 @@ namespace ink::runtime::internal
 
 		// snapshot interface
 		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 	protected:
 		// Called when we run out of space in buffer. 
@@ -390,4 +390,11 @@ namespace ink::runtime::internal
 	size_t restorable<entry>::snap(unsigned char* data, const snapper& snapper) const;
 	template<>
 	size_t restorable<int>::snap(unsigned char* data, const snapper&) const;
+
+	template<>
+	const unsigned char* restorable<value>::snap_load(const unsigned char* data, const loader&);
+	template<>
+	const unsigned char* restorable<entry>::snap_load(const unsigned char* data, const loader&);
+	template<>
+	const unsigned char* restorable<int>::snap_load(const unsigned char* data, const loader&);
 }

--- a/inkcpp/collections/restorable.h
+++ b/inkcpp/collections/restorable.h
@@ -1,7 +1,13 @@
+#pragma once
+
+#include "../snapshot_impl.h"
+
 #include <system.h>
+#include <traits.h>
 
 namespace ink::runtime::internal
 {
+	struct entry;
 	template<typename ElementType>
 	constexpr auto EmptyNullPredicate = [](const ElementType&) { return false; };
 
@@ -68,7 +74,7 @@ namespace ink::runtime::internal
 	 * from this class gain this functionality.
 	 */
 	template<typename ElementType>
-	class restorable
+	class restorable : public snapshot_interface
 	{
 	public:
 		restorable(ElementType* buffer, size_t size)
@@ -326,6 +332,10 @@ namespace ink::runtime::internal
 			return count;
 		}
 
+		// snapshot interface
+		virtual size_t snap(unsigned char* data, const snapper&) const override;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+
 	protected:
 		// Called when we run out of space in buffer. 
 		virtual void overflow(ElementType*& buffer, size_t& size) {
@@ -374,4 +384,8 @@ namespace ink::runtime::internal
 		size_t _jump;
 		size_t _save;
 	};
+	template<>
+	size_t restorable<value>::snap(unsigned char* data, const snapper& snapper) const;
+	template<>
+	size_t restorable<entry>::snap(unsigned char* data, const snapper& snapper) const;
 }

--- a/inkcpp/collections/restorable.h
+++ b/inkcpp/collections/restorable.h
@@ -334,7 +334,7 @@ namespace ink::runtime::internal
 
 		// snapshot interface
 		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 	protected:
 		// Called when we run out of space in buffer. 
@@ -388,4 +388,6 @@ namespace ink::runtime::internal
 	size_t restorable<value>::snap(unsigned char* data, const snapper& snapper) const;
 	template<>
 	size_t restorable<entry>::snap(unsigned char* data, const snapper& snapper) const;
+	template<>
+	size_t restorable<int>::snap(unsigned char* data, const snapper&) const;
 }

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -184,6 +184,7 @@ namespace ink::runtime::internal
 
 		// execute one line to startup the globals
 		run->getline_silent();
+		_globals_initialized = true;
 	}
 
 	void globals_impl::gc()
@@ -228,12 +229,22 @@ namespace ink::runtime::internal
 
 	size_t globals_impl::snap(unsigned char* data, const snapper& snapper) const
 	{
-		unsigned char* ptr;
+		unsigned char* ptr = data;
 		inkAssert(_num_containers == _visit_counts.size(), "Should be equal!");
 		inkAssert(_globals_initialized, "Only support snapshot of globals with runner! or you don't need a snapshot for this state");
 		ptr += _visit_counts.snap( data ? ptr : nullptr, snapper );
 		ptr += _strings.snap( data ? ptr : nullptr, snapper );
 		ptr += _lists.snap( data ? ptr : nullptr, snapper );
 		return ptr - data;
+	}
+
+	const unsigned char* globals_impl::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		_globals_initialized = true;
+		ptr = _visit_counts.snap_load(ptr, loader);
+		inkAssert(_num_containers == _visit_counts.size(), "errer when loading visit counts, story file dont match snapshot!");
+		ptr = _strings.snap_load(ptr, loader);
+		ptr = _lists.snap_load(ptr, loader);
+		return ptr;
 	}
 }

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -1,17 +1,21 @@
 #include "globals_impl.h"
 #include "story_impl.h"
 #include "runner_impl.h"
+#include "snapshot_impl.h"
+
+#include <cstring>
 
 namespace ink::runtime::internal
 {
 	globals_impl::globals_impl(const story_impl* story)
 		: _num_containers(story->num_containers())
-		, _visit_counts(_num_containers)
+		, _visit_counts()
 		, _owner(story)
 		, _runners_start(nullptr)
 		, _lists(story->list_meta(), story->get_header())
 		, _globals_initialized(false)
 	{
+		_visit_counts.resize(_num_containers);
 		if (_lists) {
 			// initelize static lists
 			const list_flag* flags = story->lists();
@@ -215,5 +219,21 @@ namespace ink::runtime::internal
 	void globals_impl::forget()
 	{
 		_variables.forget();
+	}
+
+	snapshot* globals_impl::create_snapshot() const
+	{
+		return new snapshot_impl(*this);
+	}
+
+	size_t globals_impl::snap(unsigned char* data, const snapper& snapper) const
+	{
+		unsigned char* ptr;
+		inkAssert(_num_containers == _visit_counts.size(), "Should be equal!");
+		inkAssert(_globals_initialized, "Only support snapshot of globals with runner! or you don't need a snapshot for this state");
+		ptr += _visit_counts.snap( data ? ptr : nullptr, snapper );
+		ptr += _strings.snap( data ? ptr : nullptr, snapper );
+		ptr += _lists.snap( data ? ptr : nullptr, snapper );
+		return ptr - data;
 	}
 }

--- a/inkcpp/globals_impl.cpp
+++ b/inkcpp/globals_impl.cpp
@@ -235,6 +235,7 @@ namespace ink::runtime::internal
 		ptr += _visit_counts.snap( data ? ptr : nullptr, snapper );
 		ptr += _strings.snap( data ? ptr : nullptr, snapper );
 		ptr += _lists.snap( data ? ptr : nullptr, snapper );
+		ptr += _variables.snap(data ? ptr : nullptr, snapper );
 		return ptr - data;
 	}
 
@@ -245,6 +246,7 @@ namespace ink::runtime::internal
 		inkAssert(_num_containers == _visit_counts.size(), "errer when loading visit counts, story file dont match snapshot!");
 		ptr = _strings.snap_load(ptr, loader);
 		ptr = _lists.snap_load(ptr, loader);
+		ptr = _variables.snap_load(ptr, loader);
 		return ptr;
 	}
 }

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -18,9 +18,9 @@ namespace ink::runtime::internal
 	class globals_impl : public globals_interface, public snapshot_interface
 	{
 		friend snapshot_impl;
+	public:
 		size_t snap(unsigned char* data, const snapper&) const override;
 		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
-	public:
 		// Initializes a new global store from the given story
 		globals_impl(const story_impl*);
 		virtual ~globals_impl() { }

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -6,19 +6,26 @@
 #include "string_table.h"
 #include "list_table.h"
 #include "stack.h"
+#include "snapshot_impl.h"
 
 namespace ink::runtime::internal
 {
 	class story_impl;
 	class runner_impl;
+	class snapshot_impl;
 
 	// Implementation of the global store
-	class globals_impl : public globals_interface
+	class globals_impl : public globals_interface, public snapshot_interface
 	{
+		friend snapshot_impl;
+		size_t snap(unsigned char* data, const snapper&) const override;
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 	public:
 		// Initializes a new global store from the given story
 		globals_impl(const story_impl*);
 		virtual ~globals_impl() { }
+
+		snapshot* create_snapshot() const override;
 
 	protected:
 		optional<uint32_t> get_uint(hash_t name) const override;
@@ -66,6 +73,7 @@ namespace ink::runtime::internal
 
 		// gets the allocated string table
 		inline string_table& strings() { return _strings; }
+		inline const string_table& strings() const { return _strings; }
 
 		// gets list entries
 		list_table& lists() { return _lists; }
@@ -93,16 +101,7 @@ namespace ink::runtime::internal
 				return !(*this == vc);
 			}
 		};
-		class visit_counts{
-			visit_count* _data;
-			size_t _len;
-		public:
-			visit_counts(size_t len) 
-			: _data{new visit_count[len]}, _len{len} {}
-			size_t size() const { return _len; }
-			visit_count& operator[](size_t i) { return _data[i]; }
-			const visit_count& operator[](size_t i) const { return _data[i]; }
-		} _visit_counts;
+		managed_array<visit_count, true, 1> _visit_counts;
 
 		// Pointer back to owner story.
 		const story_impl* const _owner;

--- a/inkcpp/include/globals.h
+++ b/inkcpp/include/globals.h
@@ -4,8 +4,7 @@
 
 namespace ink::runtime
 {
-	class globals_interface;
-	namespace internal { class globals_impl;}
+	class snapshot;
 
 	/**
 	* Represents a global store to be shared amongst ink runners.
@@ -41,6 +40,8 @@ namespace ink::runtime
 					"Requested Type is not supported");
 			return false;
 		}
+
+		virtual snapshot* create_snapshot() const = 0;
 
 		virtual ~globals_interface() = default;
 

--- a/inkcpp/include/runner.h
+++ b/inkcpp/include/runner.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "system.h"
 #include "functional.h"
+#include "types.h"
 
 #ifdef INK_ENABLE_UNREAL
 #include "Containers/UnrealString.h"
@@ -64,6 +65,12 @@ namespace ink::runtime
 		 * @return allocated c-style string with the output of a single line of execution
 		*/
 		virtual char* getline_alloc() = 0;
+
+		/**
+		 * @brief creates a snapshot containing the runner, globals and all other runners connected to the globals.
+		 * @sa story::new_runner_from_snapshot, story::new_globals_from_snapshot
+		 */
+		virtual snapshot* create_snapshot() const = 0;
 
 #ifdef INK_ENABLE_STL
 		/**

--- a/inkcpp/include/snapshot.h
+++ b/inkcpp/include/snapshot.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "types.h"
+
+namespace ink::runtime
+{
+	class snapshot {
+	public:
+		snapshot() = delete;
+		virtual ~snapshot() = 0;
+
+		static snapshot* from_binary(unsigned char* data, size_t length, bool freeOnDestroy = true);
+		static snapshot* from_file(const char* filename);
+
+		virtual const char* get_data() const = 0;
+		virtual unsigned get_data_len() const = 0;
+	};
+}

--- a/inkcpp/include/snapshot.h
+++ b/inkcpp/include/snapshot.h
@@ -6,14 +6,16 @@ namespace ink::runtime
 {
 	class snapshot {
 	public:
-		virtual ~snapshot() = 0;
+		virtual ~snapshot() {};
 
 		static snapshot* from_binary(const unsigned char* data, size_t length, bool freeOnDestroy = true);
-#ifdef INK_ENABLE_STL
-		static snapshot* from_file(const char* filename);
-#endif
 
 		virtual const unsigned char* get_data() const = 0;
 		virtual size_t get_data_len() const = 0;
+
+#ifdef INK_ENABLE_STL
+		static snapshot* from_file(const char* filename);
+		void write_to_file(const char* filename) const;
+#endif
 	};
 }

--- a/inkcpp/include/snapshot.h
+++ b/inkcpp/include/snapshot.h
@@ -12,6 +12,7 @@ namespace ink::runtime
 
 		virtual const unsigned char* get_data() const = 0;
 		virtual size_t get_data_len() const = 0;
+		virtual size_t num_runners() const = 0;
 
 #ifdef INK_ENABLE_STL
 		static snapshot* from_file(const char* filename);

--- a/inkcpp/include/snapshot.h
+++ b/inkcpp/include/snapshot.h
@@ -6,13 +6,14 @@ namespace ink::runtime
 {
 	class snapshot {
 	public:
-		snapshot() = delete;
 		virtual ~snapshot() = 0;
 
-		static snapshot* from_binary(unsigned char* data, size_t length, bool freeOnDestroy = true);
+		static snapshot* from_binary(const unsigned char* data, size_t length, bool freeOnDestroy = true);
+#ifdef INK_ENABLE_STL
 		static snapshot* from_file(const char* filename);
+#endif
 
-		virtual const char* get_data() const = 0;
-		virtual unsigned get_data_len() const = 0;
+		virtual const unsigned char* get_data() const = 0;
+		virtual size_t get_data_len() const = 0;
 	};
 }

--- a/inkcpp/include/story.h
+++ b/inkcpp/include/story.h
@@ -19,7 +19,7 @@ namespace ink::runtime
 	class story
 	{
 	public:
-		virtual ~story() = 0;
+		virtual ~story(){};
 #pragma region Interface Methods
 		/**
 		 * Creates a new global store

--- a/inkcpp/include/story.h
+++ b/inkcpp/include/story.h
@@ -19,6 +19,7 @@ namespace ink::runtime
 	class story
 	{
 	public:
+		virtual ~story() = 0;
 #pragma region Interface Methods
 		/**
 		 * Creates a new global store
@@ -30,6 +31,7 @@ namespace ink::runtime
 		 * @return managed pointer to a new global store
 		*/
 		virtual globals new_globals() = 0;
+		virtual globals new_globals_from_snapshot(const snapshot&) = 0;
 
 		/**
 		 * Creates a new runner
@@ -41,6 +43,17 @@ namespace ink::runtime
 		 * @return managed pointer to a new runner
 		*/
 		virtual runner new_runner(globals store = nullptr) = 0;
+		/**
+		 * @brief reconstruct runner from a snapshot
+		 * @attention runner must be snap_shotted from the same story
+		 * @attention if globals is explicit set,
+		 * make sure the globals are from the same snapshot as
+		 * @attention if you snap_shotted a multiple runner with shared global
+		 * please reconstruct it in the same fashion
+		 * @param store can be set if explicit access to globals is required or multiple runner with a shared global are used
+		 * @param idx if the snapshot was of a multiple runner one global situation load first the global, and then each runner with global set and increasing idx
+		 */
+		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) = 0;
 #pragma endregion
 
 #pragma region Factory Methods

--- a/inkcpp/include/traits.h
+++ b/inkcpp/include/traits.h
@@ -9,6 +9,13 @@
 
 namespace ink::runtime::internal
 {
+	template<typename ... Ts>
+	constexpr size_t sizeof_largest_type() 
+	{
+		size_t ret = 0;
+		return ( (ret = sizeof(Ts) > ret ? sizeof(Ts) : ret), ... );
+	}
+
 	template<unsigned int N, typename Arg, typename... Args>
 	struct get_ith_type : get_ith_type<N - 1, Args...> {};
 
@@ -36,6 +43,12 @@ namespace ink::runtime::internal
 
 	template<class T>
 	struct is_same<T, T> : true_type {};
+
+	template<typename T>
+	struct is_pointer : false_type {};
+
+	template<typename T>
+	struct is_pointer<T*> : true_type {};
 
 	// == string testing (from me) ==
 

--- a/inkcpp/include/types.h
+++ b/inkcpp/include/types.h
@@ -11,6 +11,7 @@ namespace ink::runtime
 {
 	class globals_interface;
 	class runner_interface;
+	class snapshot;
 
 	typedef story_ptr<globals_interface> globals;
 	typedef story_ptr<runner_interface> runner;

--- a/inkcpp/list_table.cpp
+++ b/inkcpp/list_table.cpp
@@ -650,5 +650,13 @@ namespace ink::runtime::internal
 	}
 #endif
 
+	size_t list_table::snap(unsigned char* data, const snapper& snapper) const
+	{
+		unsigned char* ptr = data;
+		ptr += _data.snap(data ? ptr : nullptr, snapper);
+		ptr += _entry_state.snap(data ? ptr : nullptr, snapper);
+		return ptr - data;
+	}
+
 }
 

--- a/inkcpp/list_table.cpp
+++ b/inkcpp/list_table.cpp
@@ -658,5 +658,12 @@ namespace ink::runtime::internal
 		return ptr - data;
 	}
 
+	const unsigned char* list_table::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		ptr = _data.snap_load(ptr, loader);
+		ptr = _entry_state.snap_load(ptr, loader);
+		return ptr;
+	}
+
 }
 

--- a/inkcpp/list_table.h
+++ b/inkcpp/list_table.h
@@ -2,6 +2,7 @@
 
 #include "system.h"
 #include "array.h"
+#include "snapshot_impl.h"
 
 #ifdef INK_ENABLE_STL
 #include <iosfwd>
@@ -24,7 +25,7 @@ namespace ink::runtime::internal
 	}
 
 	/// managed all list entries and list metadata
-	class list_table
+	class list_table : public snapshot_interface 
 	{
 		using data_t = int;
 		enum class state : char {
@@ -76,6 +77,10 @@ namespace ink::runtime::internal
 		 * @return pointer to end of insierted string
 		 */
 		char* toString(char* out, const list& l) const;
+
+		// snapshot interface implementation
+		size_t snap(unsigned char* data, const snapper&) const override;
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 		/** special traitment when a list get assignet again
 		 * when a list get assigned and would have no origin, it gets the origin of the base with origin

--- a/inkcpp/output.cpp
+++ b/inkcpp/output.cpp
@@ -499,7 +499,6 @@ namespace ink::runtime::internal
 
 	size_t basic_stream::snap(unsigned char* data, const snapper& snapper) const
 	{
-		const string_table& strings = snapper.strings;
 		unsigned char* ptr = data;
 		ptr = snap_write(ptr, _last_char, data);
 		ptr = snap_write(ptr, _size, data);
@@ -509,5 +508,18 @@ namespace ink::runtime::internal
 			ptr += itr->snap(data ? ptr : nullptr, snapper);
 		}
 		return ptr - data;
+	}
+
+	const unsigned char* basic_stream::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		ptr = snap_read(ptr, _last_char);
+		ptr = snap_read(ptr, _size);
+		ptr = snap_read(ptr, _save);
+		inkAssert(_max >= _size, "output is to small to hold stored data");
+		for(auto itr = _data; itr != _data + _size; ++itr)
+		{
+			ptr = itr->snap_load(ptr, loader);
+		}
+		return ptr;
 	}
 }

--- a/inkcpp/output.cpp
+++ b/inkcpp/output.cpp
@@ -8,500 +8,506 @@
 #include <iomanip>
 #endif
 
-namespace ink
+namespace ink::runtime::internal
 {
-	namespace runtime
+	basic_stream::basic_stream(value* buffer, size_t len)
+		: _data(buffer), _max(len), _size(0), _save(~0)
+	{}
+
+	void basic_stream::append(const value& in)
 	{
-		namespace internal
+		// SPECIAL: Incoming newline
+		if (in.type() == value_type::newline && _size > 1)
 		{
-			basic_stream::basic_stream(value* buffer, size_t len)
-				: _data(buffer), _max(len), _size(0), _save(~0)
-			{}
+			// If the end of the stream is a function start marker, we actually
+			//  want to ignore this. Function start trimming.
+			if (_data[_size - 1].type() == value_type::func_start)
+				return;
+		}
 
-			void basic_stream::append(const value& in)
+		// Ignore leading newlines
+		if (in.type() == value_type::newline && _size == 0)
+			return;
+
+		// Add to data stream
+		inkAssert(_size < _max, "Output stream overflow");
+		_data[_size++] = in;
+
+		// Special: Incoming glue. Trim whitespace/newlines prior
+		//  This also applies when a function ends to trim trailing whitespace.
+		if ((in.type() == value_type::glue || in.type() == value_type::func_end) && _size > 1)
+		{
+			// Run backwards
+			size_t i = _size - 2;
+			while(true)
 			{
-				// SPECIAL: Incoming newline
-				if (in.type() == value_type::newline && _size > 1)
-				{
-					// If the end of the stream is a function start marker, we actually
-					//  want to ignore this. Function start trimming.
-					if (_data[_size - 1].type() == value_type::func_start)
-						return;
+				value& d = _data[i];
+
+				// Nullify newlines
+				if (d.type() == value_type::newline) {
+					d = value{};
 				}
 
-				// Ignore leading newlines
-				if (in.type() == value_type::newline && _size == 0)
-					return;
+				// Nullify whitespace
+				else if ( d.type() == value_type::string 
+					&& is_whitespace(d.get<value_type::string>()))
+					d = value{};
 
-				// Add to data stream
-				inkAssert(_size < _max, "Output stream overflow");
-				_data[_size++] = in;
+				// If it's not a newline or whitespace, stop
+				else break;
 
-				// Special: Incoming glue. Trim whitespace/newlines prior
-				//  This also applies when a function ends to trim trailing whitespace.
-				if ((in.type() == value_type::glue || in.type() == value_type::func_end) && _size > 1)
-				{
-					// Run backwards
-					size_t i = _size - 2;
-					while(true)
-					{
-						value& d = _data[i];
+				// If we've hit the end, break
+				if (i == 0)
+					break;
 
-						// Nullify newlines
-						if (d.type() == value_type::newline) {
-							d = value{};
-						}
-
-						// Nullify whitespace
-						else if ( d.type() == value_type::string 
-							&& is_whitespace(d.get<value_type::string>()))
-							d = value{};
-
-						// If it's not a newline or whitespace, stop
-						else break;
-
-						// If we've hit the end, break
-						if (i == 0)
-							break;
-
-						// Move on to next element
-						i--;
-					}
-				}
+				// Move on to next element
+				i--;
 			}
+		}
+	}
 
-			void basic_stream::append(const value* in, unsigned int length)
-			{
-				// TODO: Better way to bulk while still executing glue checks?
-				for (size_t i = 0; i < length; i++)
-					append(in[i]);
-			}
+	void basic_stream::append(const value* in, unsigned int length)
+	{
+		// TODO: Better way to bulk while still executing glue checks?
+		for (size_t i = 0; i < length; i++)
+			append(in[i]);
+	}
 
-			template<typename OUT>
-			inline void write_char(OUT& output, char c)
-			{
-				static_assert(always_false<OUT>::value, "Invalid output type");
-			}
+	template<typename OUT>
+	inline void write_char(OUT& output, char c)
+	{
+		static_assert(always_false<OUT>::value, "Invalid output type");
+	}
 
-			template<>
-			inline void write_char(char*& output, char c)
-			{
-				(*output++) = c;
-			}
+	template<>
+	inline void write_char(char*& output, char c)
+	{
+		(*output++) = c;
+	}
 
-			template<>
-			inline void write_char(std::stringstream& output, char c)
-			{
-				output.put(c);
-			}
+	template<>
+	inline void write_char(std::stringstream& output, char c)
+	{
+		output.put(c);
+	}
 
-			inline bool get_next(const value* list, size_t i, size_t size, const value** next)
-			{
-				while (i + 1 < size)
-				{
-					*next = &list[i + 1];
-					value_type type = (*next)->type();
-					if ((*next)->printable()) { return true; }
-					i++;
-				}
+	inline bool get_next(const value* list, size_t i, size_t size, const value** next)
+	{
+		while (i + 1 < size)
+		{
+			*next = &list[i + 1];
+			value_type type = (*next)->type();
+			if ((*next)->printable()) { return true; }
+			i++;
+		}
 
-				return false;
-			}
+		return false;
+	}
 
-			template<typename OUT>
-			void basic_stream::copy_string(const char* str, size_t& dataIter, OUT& output)
-			{
-				while(*str != 0) {
-				write_char(output, *str++);
-				}
-			}
+	template<typename OUT>
+	void basic_stream::copy_string(const char* str, size_t& dataIter, OUT& output)
+	{
+		while(*str != 0) {
+		write_char(output, *str++);
+		}
+	}
 
 #ifdef INK_ENABLE_STL
-			std::string basic_stream::get()
-			{
-				size_t start = find_start();
+	std::string basic_stream::get()
+	{
+		size_t start = find_start();
 
-				// Move up from marker
-				bool hasGlue = false, lastNewline = false;
-				std::stringstream str;
-				for (size_t i = start; i < _size; i++)
-				{
-					if (should_skip(i, hasGlue, lastNewline))
-						continue;
-					if (_data[i].printable()){
-						_data[i].write(str, _lists_table);
-					}
-
-				}
-
-				// Reset stream size to where we last held the marker
-				_size = start;
-
-				// Return processed string
-				// remove mulitple accourencies of ' '
-				std::string result = str.str();
-				auto end = clean_string<true, false>(result.begin(), result.end());
-				_last_char = *(end-1);
-				result.resize(end - result.begin() - (_last_char == ' ' ? 1 : 0));
-				return result;
+		// Move up from marker
+		bool hasGlue = false, lastNewline = false;
+		std::stringstream str;
+		for (size_t i = start; i < _size; i++)
+		{
+			if (should_skip(i, hasGlue, lastNewline))
+				continue;
+			if (_data[i].printable()){
+				_data[i].write(str, _lists_table);
 			}
-#endif
-#ifdef INK_ENABLE_UNREAL
-			FString basic_stream::get()
-			{
-				size_t start = find_start();
-
-				// TODO: Slow! FString concatonation.
-				//  Is there really no equivilent of stringstream in Unreal? Some kind of String Builder?
-
-				// Move up from marker
-				bool hasGlue = false;
-				FString str;
-				for (size_t i = start; i < _size; i++)
-				{
-					if (should_skip(i, hasGlue))
-						continue;
-
-					switch (_data[i].type)
-					{
-					case value_type::int32:
-						str += FString::Printf(TEXT("%d"), _data[i].integer_value);
-						break;
-					case value_type::float32:
-						// TODO: Whitespace cleaning
-						str += FString::Printf(TEXT("%f"), _data[i].float_value);
-						break;
-					case value_type::string:
-						str += _data[i].string_val;
-						break;
-					case data_type::newline:
-						str += "\n";
-						break;
-					default:
-						break;
-					}
-				}
-
-				// Reset stream size to where we last held the marker
-				_size = start;
-
-				// Return processed string
-				return str;
-			}
-#endif
-
-			int basic_stream::queued() const
-			{
-				size_t start = find_start();
-				return _size - start;
-			}
-
-			const value& basic_stream::peek() const
-			{
-				inkAssert(_size > 0, "Attempting to peek empty stream!");
-				return _data[_size - 1];
-			}
-
-			void basic_stream::discard(size_t length)
-			{
-				// discard elements
-				_size -= length;
-				if (_size < 0)
-					_size = 0;
-			}
-
-			void basic_stream::get(value* ptr, size_t length)
-			{
-				// Find start
-				size_t start = find_start();
-
-				const value* end = ptr + length;
-				//inkAssert(_size - start < length, "Insufficient space in data array to store stream contents!");
-
-				// Move up from marker
-				bool hasGlue = false, lastNewline = false;
-				for (size_t i = start; i < _size; i++)
-				{
-					if (should_skip(i, hasGlue, lastNewline))
-						continue;
-
-					// Make sure we can fit the next element
-					inkAssert(ptr < end, "Insufficient space in data array to store stream contents!");
-
-					// Copy any value elements
-					if (_data[i].printable()) {
-						*(ptr++) = _data[i];
-					}
-				}
-
-				// Reset stream size to where we last held the marker
-				_size = start;
-			}
-
-			bool basic_stream::has_marker() const
-			{
-				// TODO: Cache?
-				for (size_t i = 0; i < _size; i++)
-				{
-					if (_data[i].type() == value_type::marker)
-						return true;
-				}
-
-				return false;
-			}
-
-			bool basic_stream::ends_with(value_type type) const
-			{
-				if (_size == 0)
-					return false;
-
-				return _data[_size - 1].type() == type;
-			}
-
-			bool basic_stream::saved_ends_with(value_type type) const
-			{
-				inkAssert(_save != ~0, "Stream is not saved!");
-
-				if (_save == 0)
-					return false;
-
-				return _data[_save - 1].type() == type;
-			}
-
-			void basic_stream::save()
-			{
-				inkAssert(_save == ~0, "Can not save over existing save point!");
-
-				// Save the current size
-				_save = _size;
-			}
-
-			void basic_stream::restore()
-			{
-				inkAssert(_save != ~0, "No save point to restore!");
-
-				// Restore size to saved position
-				_size = _save;
-				_save = ~0;
-			}
-
-			void basic_stream::forget()
-			{
-				inkAssert(_save != ~0, "No save point to forget!");
-
-				// Just null the save point and continue as normal
-				_save = ~0;
-			}
-			
-			template char* basic_stream::get_alloc<true>(string_table& strings, list_table& lists);
-			template char* basic_stream::get_alloc<false>(string_table& strings, list_table& lists);
-
-			template<bool RemoveTail>
-			char* basic_stream::get_alloc(string_table& strings, list_table& lists)
-			{
-				size_t start = find_start();
-
-				// Two passes. First for length
-				size_t length = 0;
-				bool hasGlue = false, lastNewline = false;
-				for (size_t i = start; i < _size; i++)
-				{
-					if (should_skip(i, hasGlue, lastNewline))
-						continue;
-					++length; // potenzial space to sperate 
-					if (_data[i].printable()) {
-						switch(_data[i].type()) {
-							case value_type::list:
-								length += lists.stringLen(_data[i].get<value_type::list>());
-								break;
-							case value_type::list_flag:
-								length += lists.stringLen(_data[i].get<value_type::list_flag>());
-							default: length += value_length(_data[i]);
-						}
-					}
-				}
-
-				// Allocate
-				char* buffer = strings.create(length + 1);
-				char* end = buffer + length + 1;
-				char* ptr = buffer;
-				hasGlue = false; lastNewline = false;
-				for (size_t i = start; i < _size; i++)
-				{
-					if (should_skip(i, hasGlue, lastNewline))
-						continue;
-					if(!_data[i].printable()) { continue; }
-					switch (_data[i].type())
-					{
-					case value_type::int32:
-					case value_type::float32:
-					case value_type::uint32:
-						// Convert to string and advance
-						toStr(ptr, end - ptr, _data[i]);
-						while (*ptr != 0) ptr++;
-
-						break;
-					case value_type::string:
-					{
-						// Copy string and advance
-						const char* value = _data[i].get<value_type::string>(); 
-						copy_string(value, i, ptr);
-					}	break;
-					case value_type::newline:
-						*ptr = '\n'; ptr++;
-						break;
-					case value_type::list:
-						ptr = lists.toString(ptr, _data[i].get<value_type::list>());
-						break;
-					case value_type::list_flag:
-						ptr = lists.toString(ptr, _data[i].get<value_type::list>());
-						break;
-					default: throw ink_exception("cant convert expression to string!");
-					}
-				}
-
-				// Make sure last character is a null
-				*ptr = 0;
-
-				// Reset stream size to where we last held the marker
-				_size = start;
-
-				// Return processed string
-				{
-				 auto end = clean_string<false,false>(buffer, buffer+length);
-				 *end = 0;
-				 _last_char = end[-1];
-				 if constexpr (RemoveTail) {
-					 if (_last_char == ' ') { end[-1] = 0; }
-				 }
-				}
-				return buffer;
-			}
-
-			size_t basic_stream::find_start() const
-			{
-				// Find marker (or start)
-				size_t start = _size;
-				while (start > 0)
-				{
-					start--;
-					if (_data[start].type() == value_type::marker)
-						break;
-				}
-
-				// Make sure we're not violating a save point
-				if (_save != ~0 && start < _save) {
-					// TODO: check if we don't reset save correct
-					// at some point we can modifiy the output even behind save (probally discard?) and push a new element -> invalid save point
-					// inkAssert(false, "Trying to access output stream prior to save point!");
-					const_cast<basic_stream&>(*this).clear();
-				}
-
-				return start;
-			}
-
-			bool basic_stream::should_skip(size_t iter, bool& hasGlue, bool& lastNewline) const
-			{
-				if (_data[iter].printable()
-						&& _data[iter].type() != value_type::newline
-						&& _data[iter].type() != value_type::string) {
-					lastNewline = false;
-					hasGlue = false; 
-				} else {
-				switch (_data[iter].type())
-				{
-					case value_type::newline:
-						if (lastNewline)
-							return true;
-						if (hasGlue)
-							return true;
-						lastNewline = true;
-						break;
-					case value_type::glue:
-						hasGlue = true;
-						break;
-					case value_type::string:
-					{
-						lastNewline = false;
-						// an empty string don't count as glued I095
-						for(const char* i=_data[iter].get<value_type::string>();
-								*i; ++i)
-						{
-							// isspace only supports characters in [0, UCHAR_MAX]
-							if (!isspace(static_cast<unsigned char>(*i))) {
-								hasGlue = false;
-								break;
-							}
-						}
-					} break;
-					default:
-						break;
-					}
-				}
-
-				return false;
-			}
-
-			bool basic_stream::text_past_save() const
-			{
-				// Check if there is text past the save
-				for (size_t i = _save; i < _size; i++)
-				{
-					const value& d = _data[i];
-					if (d.type() == value_type::string)
-					{
-						// TODO: Cache what counts as whitespace?
-						if (!is_whitespace(d.get<value_type::string>(), false))
-							return true;
-					}
-				}
-
-				// No text
-				return false;
-			}
-
-			void basic_stream::clear()
-			{
-				_save = ~0;
-				_size = 0;
-			}
-
-			void basic_stream::mark_strings(string_table& strings) const
-			{
-				// Find all allocated strings and mark them as used
-				for (int i = 0; i < _size; i++)
-				{
-					if (_data[i].type() == value_type::string) {
-						string_type str = _data[i].get<value_type::string>();
-						if (str.allocated) {
-							strings.mark_used(str.str);
-						}
-					}
-				}
-			}
-
-#ifdef INK_ENABLE_STL
-			std::ostream& operator<<(std::ostream& out, basic_stream& in)
-			{
-				out << in.get();
-				return out;
-			}
-
-			basic_stream& operator>>(basic_stream& in, std::string& out)
-			{
-				out = in.get();
-				return in;
-			}
-#endif
-#ifdef INK_ENABLE_UNREAL
-			basic_stream& operator>>(basic_stream& in, FString& out)
-			{
-				out = in.get();
-				return in;
-			}
-#endif
-
 
 		}
+
+		// Reset stream size to where we last held the marker
+		_size = start;
+
+		// Return processed string
+		// remove mulitple accourencies of ' '
+		std::string result = str.str();
+		auto end = clean_string<true, false>(result.begin(), result.end());
+		_last_char = *(end-1);
+		result.resize(end - result.begin() - (_last_char == ' ' ? 1 : 0));
+		return result;
+	}
+#endif
+#ifdef INK_ENABLE_UNREAL
+	FString basic_stream::get()
+	{
+		size_t start = find_start();
+
+		// TODO: Slow! FString concatonation.
+		//  Is there really no equivilent of stringstream in Unreal? Some kind of String Builder?
+
+		// Move up from marker
+		bool hasGlue = false;
+		FString str;
+		for (size_t i = start; i < _size; i++)
+		{
+			if (should_skip(i, hasGlue))
+				continue;
+
+			switch (_data[i].type)
+			{
+			case value_type::int32:
+				str += FString::Printf(TEXT("%d"), _data[i].integer_value);
+				break;
+			case value_type::float32:
+				// TODO: Whitespace cleaning
+				str += FString::Printf(TEXT("%f"), _data[i].float_value);
+				break;
+			case value_type::string:
+				str += _data[i].string_val;
+				break;
+			case data_type::newline:
+				str += "\n";
+				break;
+			default:
+				break;
+			}
+		}
+
+		// Reset stream size to where we last held the marker
+		_size = start;
+
+		// Return processed string
+		return str;
+	}
+#endif
+
+	int basic_stream::queued() const
+	{
+		size_t start = find_start();
+		return _size - start;
+	}
+
+	const value& basic_stream::peek() const
+	{
+		inkAssert(_size > 0, "Attempting to peek empty stream!");
+		return _data[_size - 1];
+	}
+
+	void basic_stream::discard(size_t length)
+	{
+		// discard elements
+		_size -= length;
+		if (_size < 0)
+			_size = 0;
+	}
+
+	void basic_stream::get(value* ptr, size_t length)
+	{
+		// Find start
+		size_t start = find_start();
+
+		const value* end = ptr + length;
+		//inkAssert(_size - start < length, "Insufficient space in data array to store stream contents!");
+
+		// Move up from marker
+		bool hasGlue = false, lastNewline = false;
+		for (size_t i = start; i < _size; i++)
+		{
+			if (should_skip(i, hasGlue, lastNewline))
+				continue;
+
+			// Make sure we can fit the next element
+			inkAssert(ptr < end, "Insufficient space in data array to store stream contents!");
+
+			// Copy any value elements
+			if (_data[i].printable()) {
+				*(ptr++) = _data[i];
+			}
+		}
+
+		// Reset stream size to where we last held the marker
+		_size = start;
+	}
+
+	bool basic_stream::has_marker() const
+	{
+		// TODO: Cache?
+		for (size_t i = 0; i < _size; i++)
+		{
+			if (_data[i].type() == value_type::marker)
+				return true;
+		}
+
+		return false;
+	}
+
+	bool basic_stream::ends_with(value_type type) const
+	{
+		if (_size == 0)
+			return false;
+
+		return _data[_size - 1].type() == type;
+	}
+
+	bool basic_stream::saved_ends_with(value_type type) const
+	{
+		inkAssert(_save != ~0, "Stream is not saved!");
+
+		if (_save == 0)
+			return false;
+
+		return _data[_save - 1].type() == type;
+	}
+
+	void basic_stream::save()
+	{
+		inkAssert(_save == ~0, "Can not save over existing save point!");
+
+		// Save the current size
+		_save = _size;
+	}
+
+	void basic_stream::restore()
+	{
+		inkAssert(_save != ~0, "No save point to restore!");
+
+		// Restore size to saved position
+		_size = _save;
+		_save = ~0;
+	}
+
+	void basic_stream::forget()
+	{
+		inkAssert(_save != ~0, "No save point to forget!");
+
+		// Just null the save point and continue as normal
+		_save = ~0;
+	}
+	
+	template char* basic_stream::get_alloc<true>(string_table& strings, list_table& lists);
+	template char* basic_stream::get_alloc<false>(string_table& strings, list_table& lists);
+
+	template<bool RemoveTail>
+	char* basic_stream::get_alloc(string_table& strings, list_table& lists)
+	{
+		size_t start = find_start();
+
+		// Two passes. First for length
+		size_t length = 0;
+		bool hasGlue = false, lastNewline = false;
+		for (size_t i = start; i < _size; i++)
+		{
+			if (should_skip(i, hasGlue, lastNewline))
+				continue;
+			++length; // potenzial space to sperate 
+			if (_data[i].printable()) {
+				switch(_data[i].type()) {
+					case value_type::list:
+						length += lists.stringLen(_data[i].get<value_type::list>());
+						break;
+					case value_type::list_flag:
+						length += lists.stringLen(_data[i].get<value_type::list_flag>());
+					default: length += value_length(_data[i]);
+				}
+			}
+		}
+
+		// Allocate
+		char* buffer = strings.create(length + 1);
+		char* end = buffer + length + 1;
+		char* ptr = buffer;
+		hasGlue = false; lastNewline = false;
+		for (size_t i = start; i < _size; i++)
+		{
+			if (should_skip(i, hasGlue, lastNewline))
+				continue;
+			if(!_data[i].printable()) { continue; }
+			switch (_data[i].type())
+			{
+			case value_type::int32:
+			case value_type::float32:
+			case value_type::uint32:
+				// Convert to string and advance
+				toStr(ptr, end - ptr, _data[i]);
+				while (*ptr != 0) ptr++;
+
+				break;
+			case value_type::string:
+			{
+				// Copy string and advance
+				const char* value = _data[i].get<value_type::string>(); 
+				copy_string(value, i, ptr);
+			}	break;
+			case value_type::newline:
+				*ptr = '\n'; ptr++;
+				break;
+			case value_type::list:
+				ptr = lists.toString(ptr, _data[i].get<value_type::list>());
+				break;
+			case value_type::list_flag:
+				ptr = lists.toString(ptr, _data[i].get<value_type::list>());
+				break;
+			default: throw ink_exception("cant convert expression to string!");
+			}
+		}
+
+		// Make sure last character is a null
+		*ptr = 0;
+
+		// Reset stream size to where we last held the marker
+		_size = start;
+
+		// Return processed string
+		{
+		 auto end = clean_string<false,false>(buffer, buffer+length);
+		 *end = 0;
+		 _last_char = end[-1];
+		 if constexpr (RemoveTail) {
+			 if (_last_char == ' ') { end[-1] = 0; }
+		 }
+		}
+		return buffer;
+	}
+
+	size_t basic_stream::find_start() const
+	{
+		// Find marker (or start)
+		size_t start = _size;
+		while (start > 0)
+		{
+			start--;
+			if (_data[start].type() == value_type::marker)
+				break;
+		}
+
+		// Make sure we're not violating a save point
+		if (_save != ~0 && start < _save) {
+			// TODO: check if we don't reset save correct
+			// at some point we can modifiy the output even behind save (probally discard?) and push a new element -> invalid save point
+			// inkAssert(false, "Trying to access output stream prior to save point!");
+			const_cast<basic_stream&>(*this).clear();
+		}
+
+		return start;
+	}
+
+	bool basic_stream::should_skip(size_t iter, bool& hasGlue, bool& lastNewline) const
+	{
+		if (_data[iter].printable()
+				&& _data[iter].type() != value_type::newline
+				&& _data[iter].type() != value_type::string) {
+			lastNewline = false;
+			hasGlue = false; 
+		} else {
+		switch (_data[iter].type())
+		{
+			case value_type::newline:
+				if (lastNewline)
+					return true;
+				if (hasGlue)
+					return true;
+				lastNewline = true;
+				break;
+			case value_type::glue:
+				hasGlue = true;
+				break;
+			case value_type::string:
+			{
+				lastNewline = false;
+				// an empty string don't count as glued I095
+				for(const char* i=_data[iter].get<value_type::string>();
+						*i; ++i)
+				{
+					// isspace only supports characters in [0, UCHAR_MAX]
+					if (!isspace(static_cast<unsigned char>(*i))) {
+						hasGlue = false;
+						break;
+					}
+				}
+			} break;
+			default:
+				break;
+			}
+		}
+
+		return false;
+	}
+
+	bool basic_stream::text_past_save() const
+	{
+		// Check if there is text past the save
+		for (size_t i = _save; i < _size; i++)
+		{
+			const value& d = _data[i];
+			if (d.type() == value_type::string)
+			{
+				// TODO: Cache what counts as whitespace?
+				if (!is_whitespace(d.get<value_type::string>(), false))
+					return true;
+			}
+		}
+
+		// No text
+		return false;
+	}
+
+	void basic_stream::clear()
+	{
+		_save = ~0;
+		_size = 0;
+	}
+
+	void basic_stream::mark_strings(string_table& strings) const
+	{
+		// Find all allocated strings and mark them as used
+		for (int i = 0; i < _size; i++)
+		{
+			if (_data[i].type() == value_type::string) {
+				string_type str = _data[i].get<value_type::string>();
+				if (str.allocated) {
+					strings.mark_used(str.str);
+				}
+			}
+		}
+	}
+
+#ifdef INK_ENABLE_STL
+	std::ostream& operator<<(std::ostream& out, basic_stream& in)
+	{
+		out << in.get();
+		return out;
+	}
+
+	basic_stream& operator>>(basic_stream& in, std::string& out)
+	{
+		out = in.get();
+		return in;
+	}
+#endif
+#ifdef INK_ENABLE_UNREAL
+	basic_stream& operator>>(basic_stream& in, FString& out)
+	{
+		out = in.get();
+		return in;
+	}
+#endif
+
+	size_t basic_stream::snap(unsigned char* data, const snapper& snapper) const
+	{
+		const string_table& strings = snapper.strings;
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _last_char, data);
+		ptr = snap_write(ptr, _size, data);
+		ptr = snap_write(ptr, _save, data);
+		for(auto itr = _data; itr != _data + _size; ++itr)
+		{
+			ptr += itr->snap(data ? ptr : nullptr, snapper);
+		}
+		return ptr - data;
 	}
 }

--- a/inkcpp/output.h
+++ b/inkcpp/output.h
@@ -102,7 +102,7 @@ namespace ink
 
 				// snapshot interface
 				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 			private:
 				size_t find_start() const;

--- a/inkcpp/output.h
+++ b/inkcpp/output.h
@@ -102,7 +102,7 @@ namespace ink
 
 				// snapshot interface
 				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 			private:
 				size_t find_start() const;

--- a/inkcpp/output.h
+++ b/inkcpp/output.h
@@ -2,6 +2,7 @@
 
 #include "value.h"
 #include "platform.h"
+#include "snapshot_impl.h"
 
 namespace ink
 {
@@ -11,7 +12,7 @@ namespace ink
 		{
 			class string_table;
 			class list_table;
-			class basic_stream
+			class basic_stream : public snapshot_interface
 			{
 			protected:
 				basic_stream(value*, size_t);
@@ -98,6 +99,10 @@ namespace ink
 				}
 
 				bool saved() const { return _save != ~0; }
+
+				// snapshot interface
+				size_t snap(unsigned char* data, const snapper&) const override;
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 			private:
 				size_t find_start() const;

--- a/inkcpp/random.h
+++ b/inkcpp/random.h
@@ -7,15 +7,15 @@ namespace ink::runtime::internal {
 	 * @brief pseudo random number generator based on Linear Congruential Generator.
 	 */
 	class prng {
-		static constexpr uint32_t C = 12345;
-		static constexpr uint32_t A = 1103515245;
-		static constexpr uint32_t M = 1<<31;
+		static constexpr uint64_t C = 12345;
+		static constexpr uint64_t A = 1103515245;
+		static constexpr uint64_t M = 1<<31;
 	public:
 		void srand(int32_t seed) {
 			_x = seed;
 		}
 		uint32_t rand() {
-			_x = (A*_x+ C) % M;
+			_x = static_cast<uint32_t>((A*_x+ C) % M);
 			return _x;
 		}
 		int32_t rand(int32_t max) {
@@ -23,6 +23,7 @@ namespace ink::runtime::internal {
 			prod *= max;
 			return static_cast<int32_t>(prod / M);
 		}
+		uint32_t get_state() const { return _x; }
 	private:
 		uint32_t _x = 1337;
 	};

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -540,7 +540,6 @@ namespace ink::runtime::internal
 		ptr = snap_write(ptr, _rng.get_state(), data);
 		ptr = snap_write(ptr, _evaluation_mode, data);
 		ptr = snap_write(ptr, _saved_evaluation_mode, data);
-		ptr = snap_write(ptr, _eval, data);
 		ptr = snap_write(ptr, _saved, data);
 		ptr = snap_write(ptr, _is_falling, data);
 		ptr += _output.snap(data ? ptr : nullptr, snapper);
@@ -585,7 +584,6 @@ namespace ink::runtime::internal
 		_rng.srand(seed);
 		ptr = snap_read(ptr, _evaluation_mode);
 		ptr = snap_read(ptr, _saved_evaluation_mode);
-		ptr = snap_read(ptr, _eval);
 		ptr = snap_read(ptr, _saved);
 		ptr = snap_read(ptr, _is_falling);
 		ptr = _output.snap_load(ptr, loader);
@@ -632,6 +630,12 @@ namespace ink::runtime::internal
 		ptr += base::snap(data ? ptr : nullptr, snapper);
 		ptr += _threadDone.snap(data ? ptr : nullptr, snapper);
 		return ptr - data;
+	}
+	const unsigned char* runner_impl::threads::snap_load(const unsigned char* ptr, const loader& loader) 
+	{
+		ptr = base::snap_load(ptr, loader);
+		ptr = _threadDone.snap_load(ptr, loader);
+		return ptr;
 	}
 
 #ifdef INK_ENABLE_CSTD

--- a/inkcpp/runner_impl.h
+++ b/inkcpp/runner_impl.h
@@ -202,7 +202,7 @@ namespace ink::runtime::internal
 
 			// snapshot interface
 			size_t snap(unsigned char* data, const snapper&) const override;
-			const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+			const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 		protected:
 			virtual void overflow(thread_t*& buffer, size_t& size) override final;

--- a/inkcpp/runner_impl.h
+++ b/inkcpp/runner_impl.h
@@ -202,7 +202,7 @@ namespace ink::runtime::internal
 
 			// snapshot interface
 			size_t snap(unsigned char* data, const snapper&) const override;
-			const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+			const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 		protected:
 			virtual void overflow(thread_t*& buffer, size_t& size) override final;

--- a/inkcpp/runner_impl.h
+++ b/inkcpp/runner_impl.h
@@ -200,6 +200,10 @@ namespace ink::runtime::internal
 			}
 			const ip_t& operator[](size_t index) const { return get(index); }
 
+			// snapshot interface
+			size_t snap(unsigned char* data, const snapper&) const override;
+			const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+
 		protected:
 			virtual void overflow(thread_t*& buffer, size_t& size) override final;
 		private:

--- a/inkcpp/simple_restorable_stack.h
+++ b/inkcpp/simple_restorable_stack.h
@@ -29,7 +29,7 @@ namespace ink::runtime::internal
 		void forget();
 
 		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 	protected:
 		virtual void overflow(T*& buffer, size_t& size) {
@@ -229,7 +229,7 @@ namespace ink::runtime::internal
 	template<typename T>
 	size_t simple_restorable_stack<T>::snap(unsigned char* data, const snapper&) const
 	{
-		static_assert(is_same<T, container_t>{}() || is_same<T, thread_t>{}());
+		static_assert(is_same<T, container_t>{}() || is_same<T, thread_t>{}() || is_same<T, int>{}());
 		unsigned char* ptr = data;
 		ptr = snap_write(ptr, _null, data);
 		ptr = snap_write(ptr, _pos, data);

--- a/inkcpp/simple_restorable_stack.h
+++ b/inkcpp/simple_restorable_stack.h
@@ -2,11 +2,12 @@
 
 #include "system.h"
 #include "array.h"
+#include "snapshot_impl.h"
 
 namespace ink::runtime::internal
 {
 	template<typename T>
-	class simple_restorable_stack
+	class simple_restorable_stack : public snapshot_interface
 	{
 	public:
 		simple_restorable_stack(T* buffer, size_t size, const T& null)
@@ -26,6 +27,9 @@ namespace ink::runtime::internal
 		void save();
 		void restore();
 		void forget();
+
+		virtual size_t snap(unsigned char* data, const snapper&) const override;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 	protected:
 		virtual void overflow(T*& buffer, size_t& size) {
@@ -221,5 +225,23 @@ namespace ink::runtime::internal
 
 		// Just reset save position
 		_save = InvalidIndex;
+	}
+	template<typename T>
+	size_t simple_restorable_stack<T>::snap(unsigned char* data, const snapper&) const
+	{
+		static_assert(is_same<T, container_t>{}() || is_same<T, thread_t>{}());
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _null, data);
+		ptr = snap_write(ptr, _pos, data);
+		ptr = snap_write(ptr, _save, data);
+		ptr = snap_write(ptr, _jump, data);
+		size_t max = _pos;
+		if (_save > max) { max = _save; }
+		if (_jump > max) { max = _jump; }
+		for(size_t i = 0; i < max; ++i)
+		{
+			ptr = snap_write(ptr, _buffer[i], data);
+		}
+		return ptr - data;
 	}
 }

--- a/inkcpp/snapshot_impl.cpp
+++ b/inkcpp/snapshot_impl.cpp
@@ -61,8 +61,8 @@ namespace ink::runtime::internal
 		: _managed{true}
 	{
 		snapshot_interface::snapper snapper{
-			.strings = globals.strings(),
-			.story_string_table = globals._owner->string(0)
+			globals.strings(),
+			globals._owner->string(0)
 		};
 		_length = globals.snap(nullptr, snapper);
 		size_t runner_cnt = 0;

--- a/inkcpp/snapshot_impl.cpp
+++ b/inkcpp/snapshot_impl.cpp
@@ -1,0 +1,83 @@
+#include "snapshot_impl.h"
+#include "globals_impl.h"
+#include "runner_impl.h"
+
+#include <cstring>
+#ifdef INK_ENABLE_STL
+#include <fstream>
+#endif
+
+namespace ink::runtime
+{
+	snapshot* snapshot::from_binary(const unsigned char* data, size_t length, bool freeOnDestroy)
+	{
+		return new internal::snapshot_impl(data, length, freeOnDestroy);
+	}
+
+#ifdef INK_ENABLE_STL
+	snapshot* snapshot::from_file(const char* filename) {
+		std::ifstream ifs(filename, std::ios::binary | std::ios::ate);
+		if(!ifs.is_open()) {
+			throw ink_exception("Failed to open snapshot file: " + std::string(filename));
+		}
+
+		size_t length = static_cast<size_t>(ifs.tellg());
+		unsigned char* data = new unsigned char[length];
+		ifs.seekg(0, std::ios::beg);
+		ifs.read(reinterpret_cast<char*>(data), length);
+		ifs.close();
+
+		return from_binary(data, length);
+	}
+#endif
+}
+
+namespace ink::runtime::internal
+{
+	size_t snapshot_impl::file_size(size_t serialization_length, size_t runner_cnt) {
+		return serialization_length + sizeof(header) + runner_cnt * sizeof(size_t);
+	}
+
+	const unsigned char* snapshot_impl::get_data() const {
+		return _file;
+	}
+	size_t snapshot_impl::get_data_len() const {
+		return _length;
+	}
+
+	snapshot_impl::snapshot_impl(const globals_impl& globals)
+		: _managed{true}
+	{
+		_length = globals.snap();
+		size_t runner_cnt = 0;
+		for(auto node = globals._runners_start; node; node = node->next)
+		{
+			_length += node->object->snap();
+			++runner_cnt;
+		}
+		
+		_length = file_size(_length, runner_cnt);
+		unsigned char* data = new unsigned char[_length];
+		_file = data;
+		unsigned char* ptr = data;
+		// write header
+		memcpy(ptr, &_header, sizeof(_header));
+		// write lookup table
+		ptr += sizeof(header);
+		{
+			size_t offset = 0;
+			for(auto node = globals._runners_start; node; node = node->next)
+			{
+				offset += node->object->snap();
+				memcpy(ptr, &offset, sizeof(offset));
+				ptr += sizeof(offset);
+			}
+		}
+
+		ptr += globals.snap(ptr);
+		for (auto node = globals._runners_start; node; node = node->next)
+		{
+			ptr += node->object->snap(ptr);
+		}
+	}
+}

--- a/inkcpp/snapshot_impl.h
+++ b/inkcpp/snapshot_impl.h
@@ -36,7 +36,7 @@ namespace ink::runtime::internal
 			return _file + get_offset(idx + 1);
 		}
 
-		size_t num_runners() const { return _header.num_runners; }
+		size_t num_runners() override const { return _header.num_runners; }
 
 	private:
 		// file information

--- a/inkcpp/snapshot_impl.h
+++ b/inkcpp/snapshot_impl.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "snapshot.h"
+
+#include <cstring>
+
+namespace ink::runtime::internal
+{
+	class globals_impl;
+	class value;
+	class string_table;
+	class snapshot_interface {
+	protected:
+		static unsigned char* snap_write(unsigned char* ptr, const void* data, size_t length, bool write)
+		{
+			memcpy(ptr, data, length);
+			return ptr += length;
+		}
+		template<typename T>
+		static unsigned char* snap_write(unsigned char* ptr, const T& data, bool write)
+		{
+				return snap_write(ptr, &data, sizeof(data), write);
+		}
+	public:
+		struct snapper {
+			const string_table& strings;
+		};
+		struct loader {
+			string_table& strings;
+		};
+		virtual size_t snap(unsigned char* data, const snapper&) const = 0;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) = 0;
+	};
+	class snapshot_impl : public snapshot
+	{
+	public:
+		~snapshot_impl() override {
+			if (_managed) { delete[] _file; }
+		};
+		const unsigned char* get_data() const override;
+		size_t get_data_len() const override;
+
+		snapshot_impl(const globals_impl&);
+			// write down all allocated strings
+			// replace pointer with idx
+			// reconsrtuct static strings index
+			// list_table _data & _entry_state
+		snapshot_impl(const unsigned char* data, size_t length, bool managed);
+
+	private:
+		// file information
+		const unsigned char* _file;
+		size_t _length;
+		bool _managed;
+		static size_t file_size(size_t, size_t);
+		struct header {
+			size_t num_runners;
+			size_t length;
+
+		} _header;
+	};
+}

--- a/inkcpp/snapshot_impl.h
+++ b/inkcpp/snapshot_impl.h
@@ -24,6 +24,7 @@ namespace ink::runtime::internal
 	public:
 		struct snapper {
 			const string_table& strings;
+			const char* story_string_table;
 		};
 		struct loader {
 			string_table& strings;

--- a/inkcpp/snapshot_impl.h
+++ b/inkcpp/snapshot_impl.h
@@ -36,6 +36,8 @@ namespace ink::runtime::internal
 			return _file + get_offset(idx + 1);
 		}
 
+		size_t num_runners() const { return _header.num_runners; }
+
 	private:
 		// file information
 		// only populated when loading snapshots

--- a/inkcpp/snapshot_impl.h
+++ b/inkcpp/snapshot_impl.h
@@ -36,7 +36,7 @@ namespace ink::runtime::internal
 			return _file + get_offset(idx + 1);
 		}
 
-		size_t num_runners() override const { return _header.num_runners; }
+		size_t num_runners() const override { return _header.num_runners; }
 
 	private:
 		// file information

--- a/inkcpp/snapshot_interface.h
+++ b/inkcpp/snapshot_interface.h
@@ -10,8 +10,10 @@ namespace ink::runtime::internal
 	class string_table;
 	template<typename,bool,size_t>
 	class managed_array;
+
 	class snapshot_interface {
 	public:
+		constexpr snapshot_interface(){};
 		static unsigned char* snap_write(unsigned char* ptr, const void* data, size_t length, bool write)
 		{
 			if (write) { memcpy(ptr, data, length); }

--- a/inkcpp/snapshot_interface.h
+++ b/inkcpp/snapshot_interface.h
@@ -11,7 +11,7 @@ namespace ink::runtime::internal
 	template<typename,bool,size_t>
 	class managed_array;
 	class snapshot_interface {
-	protected:
+	public:
 		static unsigned char* snap_write(unsigned char* ptr, const void* data, size_t length, bool write)
 		{
 			if (write) { memcpy(ptr, data, length); }
@@ -32,7 +32,7 @@ namespace ink::runtime::internal
 		{
 			return snap_read(ptr, &data, sizeof(data));
 		}
-	public:
+
 		struct snapper {
 			const string_table& strings;
 			const char* story_string_table;

--- a/inkcpp/snapshot_interface.h
+++ b/inkcpp/snapshot_interface.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "snapshot.h"
+#include <cstring>
+
+namespace ink::runtime::internal
+{
+	class globals_impl;
+	class value;
+	class string_table;
+	template<typename,bool,size_t>
+	class managed_array;
+	class snapshot_interface {
+	protected:
+		static unsigned char* snap_write(unsigned char* ptr, const void* data, size_t length, bool write)
+		{
+			if (write) { memcpy(ptr, data, length); }
+			return ptr + length;
+		}
+		template<typename T>
+		static unsigned char* snap_write(unsigned char* ptr, const T& data, bool write)
+		{
+				return snap_write(ptr, &data, sizeof(data), write);
+		}
+		static const unsigned char* snap_read(const unsigned char* ptr, void* data, size_t length)
+		{
+			memcpy(data, ptr, length);
+			return ptr + length;
+		}
+		template<typename T>
+		static const unsigned char* snap_read(const unsigned char* ptr, T& data)
+		{
+			return snap_read(ptr, &data, sizeof(data));
+		}
+	public:
+		struct snapper {
+			const string_table& strings;
+			const char* story_string_table;
+		};
+		struct loader {
+			managed_array<const char*, true, 5>& string_table;
+			const char* story_string_table;
+		};
+		virtual size_t snap(unsigned char* data, const snapper&) const = 0;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) = 0;
+	};
+}

--- a/inkcpp/stack.cpp
+++ b/inkcpp/stack.cpp
@@ -587,4 +587,13 @@ namespace ink::runtime::internal
 			stack.set(itr.get()->name, itr.get()->data);
 		}
 	}
+
+	size_t basic_stack::snap(unsigned char* data, const snapper& snapper) const
+	{
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, _next_thread, data);
+		ptr = snap_write(ptr, _backup_next_thread, data);
+		ptr += base::snap(data ? ptr : nullptr, snapper);
+		return ptr - data;
+	}
 }

--- a/inkcpp/stack.cpp
+++ b/inkcpp/stack.cpp
@@ -596,4 +596,12 @@ namespace ink::runtime::internal
 		ptr += base::snap(data ? ptr : nullptr, snapper);
 		return ptr - data;
 	}
+
+	const unsigned char* basic_stack::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		ptr = snap_read(ptr, _next_thread);
+		ptr = snap_read(ptr, _backup_next_thread);
+		ptr = base::snap_load(ptr, loader);
+		return ptr;
+	}
 }

--- a/inkcpp/stack.h
+++ b/inkcpp/stack.h
@@ -3,6 +3,7 @@
 #include "value.h"
 #include "collections/restorable.h"
 #include "array.h"
+#include "snapshot_impl.h"
 
 namespace ink
 {
@@ -24,7 +25,7 @@ namespace ink
 				thread
 			};
 
-			class basic_stack : protected restorable<entry>
+			class basic_stack : protected restorable<entry> 
 			{
 			protected:
 				basic_stack(entry* data, size_t size);
@@ -78,6 +79,10 @@ namespace ink
 				void fetch_values(basic_stack& _stack);
 				// push all values to other _stack
 				void push_values(basic_stack& _stack);
+
+				// snapshot interface
+				size_t snap(unsigned char* data, const snapper&) const override;
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 			private:
 				entry& add(hash_t name, const value& val);
@@ -135,6 +140,7 @@ namespace ink
 				using base = restorable<value>;
 
 			public:
+
 				// Push value onto the stack
 				void push(const value&);
 
@@ -160,6 +166,12 @@ namespace ink
 				void save();
 				void restore();
 				void forget();
+
+				// snapshot interface
+				size_t snap(unsigned char* data, const snapper& snapper) const override
+				{ return base::snap(data, snapper); }
+				const unsigned char* snap_load(const unsigned char* data, const loader& loader) override
+				{ return base::snap_load(data, loader); }
 			};
 
 			template<size_t N, bool dynamic = false>

--- a/inkcpp/stack.h
+++ b/inkcpp/stack.h
@@ -82,7 +82,7 @@ namespace ink
 
 				// snapshot interface
 				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 			private:
 				entry& add(hash_t name, const value& val);

--- a/inkcpp/stack.h
+++ b/inkcpp/stack.h
@@ -82,7 +82,7 @@ namespace ink
 
 				// snapshot interface
 				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+				const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 			private:
 				entry& add(hash_t name, const value& val);

--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -236,6 +236,8 @@ namespace ink::runtime::internal
 			_list_meta = nullptr;
 			_lists = nullptr;
 		}
+		inkAssert(_header.endien == header::endian_types::same,
+				"different endien support not yet implemented");
 
 
 

--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -2,6 +2,8 @@
 #include "platform.h"
 #include "runner_impl.h"
 #include "globals_impl.h"
+#include "snapshot.h"
+#include "snapshot_impl.h"
 #include "version.h"
 
 #ifdef INK_ENABLE_STL
@@ -173,6 +175,19 @@ namespace ink::runtime::internal
 	{
 		// create the new globals store
 		return globals(new globals_impl(this), _block);
+	}
+
+	globals story_impl::new_globals_from_snapshot(const snapshot& data)
+	{
+		const snapshot_impl& snapshot = reinterpret_cast<const snapshot_impl&>(data);
+		auto* globs = new globals_impl(this);
+		auto end = globs->snap_load(snapshot.get_globals_snap(), snapshot_interface::loader{
+			.string_table = snapshot.strings(),
+			.story_string_table = _string_table,
+
+		});
+		inkAssert(end == snapshot.get_runner_snap(0), "not all data were used for global reconstruction");
+		return globals(globs, _block);
 	}
 
 	runner story_impl::new_runner(globals store)

--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -182,9 +182,8 @@ namespace ink::runtime::internal
 		const snapshot_impl& snapshot = reinterpret_cast<const snapshot_impl&>(data);
 		auto* globs = new globals_impl(this);
 		auto end = globs->snap_load(snapshot.get_globals_snap(), snapshot_interface::loader{
-			.string_table = snapshot.strings(),
-			.story_string_table = _string_table,
-
+			snapshot.strings(),
+			_string_table,
 		});
 		inkAssert(end == snapshot.get_runner_snap(0), "not all data were used for global reconstruction");
 		return globals(globs, _block);
@@ -205,8 +204,8 @@ namespace ink::runtime::internal
 		auto* run = new runner_impl(this, store);
 		auto end = run->snap_load(snapshot.get_runner_snap(idx),
 				snapshot_interface::loader{
-					.string_table = snapshot.strings(),
-					.story_string_table = _string_table, 
+					snapshot.strings(),
+					_string_table, 
 				});
 		inkAssert(
 			(idx + 1 < snapshot.num_runners() && end == snapshot.get_runner_snap(idx + 1))

--- a/inkcpp/story_impl.h
+++ b/inkcpp/story_impl.h
@@ -42,7 +42,10 @@ namespace ink::runtime::internal
 		virtual globals new_globals() override;
 		virtual globals new_globals_from_snapshot(const snapshot&) override;
 		virtual runner new_runner(globals store = nullptr) override;
-		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) override;
+		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) override {
+			inkAssert(false, "not implmented yet!");
+			return nullptr;
+		}
 
 
 		const ink::internal::header& get_header() const { return _header; }

--- a/inkcpp/story_impl.h
+++ b/inkcpp/story_impl.h
@@ -40,7 +40,9 @@ namespace ink::runtime::internal
 
 		// Creates a new global store for use with runners executing this story
 		virtual globals new_globals() override;
+		virtual globals new_globals_from_snapshot(const snapshot&) override;
 		virtual runner new_runner(globals store = nullptr) override;
+		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) override;
 
 
 		const ink::internal::header& get_header() const { return _header; }

--- a/inkcpp/story_impl.h
+++ b/inkcpp/story_impl.h
@@ -42,11 +42,7 @@ namespace ink::runtime::internal
 		virtual globals new_globals() override;
 		virtual globals new_globals_from_snapshot(const snapshot&) override;
 		virtual runner new_runner(globals store = nullptr) override;
-		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) override {
-			inkAssert(false, "not implmented yet!");
-			return nullptr;
-		}
-
+		virtual runner new_runner_from_snapshot(const snapshot&, globals store = nullptr, unsigned idx = 0) override;
 
 		const ink::internal::header& get_header() const { return _header; }
 	private:

--- a/inkcpp/string_table.cpp
+++ b/inkcpp/string_table.cpp
@@ -104,4 +104,26 @@ namespace ink::runtime::internal
 		ptr = snap_write(ptr, "\0", 1, data);
 		return ptr - data;
 	}
+
+	const unsigned char* string_table::snap_load(const unsigned char* data, const loader& loader)
+	{
+		auto* ptr = data;
+		while(*ptr) {
+			size_t len = 0;
+			for(;ptr[len];++len);
+			++len;
+			auto str = create(len);
+			loader.string_table.push() = str;
+			ptr = snap_read(ptr, str, len);
+			mark_used(str);
+		}
+		return ptr + 1;
+	}
+
+	size_t string_table::get_id(const char* string) const
+	{
+		auto iter = _table.find(string);
+		inkAssert(iter != _table.end(), "Try to fetch not contained string!");
+		return iter.temp_identifier();
+	}
 }

--- a/inkcpp/string_table.cpp
+++ b/inkcpp/string_table.cpp
@@ -94,4 +94,14 @@ namespace ink::runtime::internal
 			iter++;
 		}
 	}
+
+	size_t string_table::snap(unsigned char* data, const snapper&) const
+	{
+		unsigned char* ptr = data;
+		for(auto itr = _table.begin(); itr != _table.end(); ++itr) {
+			ptr = snap_write(ptr, itr.key(), strlen(itr.key()) + 1, data);
+		}
+		ptr = snap_write(ptr, "\0", 1, data);
+		return ptr - data;
+	}
 }

--- a/inkcpp/string_table.cpp
+++ b/inkcpp/string_table.cpp
@@ -98,8 +98,13 @@ namespace ink::runtime::internal
 	size_t string_table::snap(unsigned char* data, const snapper&) const
 	{
 		unsigned char* ptr = data;
-		for(auto itr = _table.begin(); itr != _table.end(); ++itr) {
-			ptr = snap_write(ptr, itr.key(), strlen(itr.key()) + 1, data);
+		for (size_t i = 0; i < _table.size(); ++i) {
+			for(auto itr = _table.begin(); itr != _table.end(); ++itr) {
+				if (itr.temp_identifier() == i) {
+					ptr = snap_write(ptr, itr.key(), strlen(itr.key()) + 1, data);
+					break;
+				}
+			}
 		}
 		ptr = snap_write(ptr, "\0", 1, data);
 		return ptr - data;
@@ -108,6 +113,7 @@ namespace ink::runtime::internal
 	const unsigned char* string_table::snap_load(const unsigned char* data, const loader& loader)
 	{
 		auto* ptr = data;
+		int i = 0;
 		while(*ptr) {
 			size_t len = 0;
 			for(;ptr[len];++len);

--- a/inkcpp/string_table.h
+++ b/inkcpp/string_table.h
@@ -2,11 +2,12 @@
 
 #include "avl_array.h"
 #include "system.h"
+#include "snapshot_impl.h"
 
 namespace ink::runtime::internal
 {
 	// hash tree sorted by string pointers
-	class string_table
+	class string_table : public snapshot_interface
 	{
 	public:
 		~string_table();
@@ -20,6 +21,15 @@ namespace ink::runtime::internal
 
 		// mark a string as used
 		void mark_used(const char* string);
+
+
+		// snapshot interface implementation
+		size_t snap(unsigned char* data, const snapper&) const override;
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+
+		// get position of string when iterate through data
+		// used to enable storing a string table references
+		void get_id(const char* string);
 
 		// deletes all unused strings
 		void gc();

--- a/inkcpp/string_table.h
+++ b/inkcpp/string_table.h
@@ -29,7 +29,7 @@ namespace ink::runtime::internal
 
 		// get position of string when iterate through data
 		// used to enable storing a string table references
-		void get_id(const char* string);
+		size_t get_id(const char* string) const;
 
 		// deletes all unused strings
 		void gc();

--- a/inkcpp/value.cpp
+++ b/inkcpp/value.cpp
@@ -76,7 +76,7 @@ namespace ink::runtime::internal
 		unsigned char* ptr = data;
 		ptr = snap_write(ptr, _type, data);
 		if (_type == value_type::string) {
-			unsigned char buf[max_value_size];
+			unsigned char buf[max_value_size()];
 			string_type* res = reinterpret_cast<string_type*>(buf);
 			auto str = get<value_type::string>();
 			res->allocated = str.allocated;
@@ -88,14 +88,14 @@ namespace ink::runtime::internal
 			ptr = snap_write(ptr, buf, data);
 		} else {
 			// TODO more space efficent?
-			ptr = snap_write(ptr, &bool_value, max_value_size, data);
+			ptr = snap_write(ptr, &bool_value, max_value_size(), data);
 		}
 		return ptr - data;
 	}
 	const unsigned char* value::snap_load(const unsigned char* ptr, const loader& loader)
 	{
 		ptr = snap_read(ptr, _type);
-		ptr = snap_read(ptr, &bool_value, max_value_size);
+		ptr = snap_read(ptr, &bool_value, max_value_size());
 		if(_type == value_type::string) {
 			if(string_value.allocated) {
 				string_value.str = loader.string_table[(std::uintptr_t)(string_value.str)];

--- a/inkcpp/value.cpp
+++ b/inkcpp/value.cpp
@@ -92,4 +92,17 @@ namespace ink::runtime::internal
 		}
 		return ptr - data;
 	}
+	const unsigned char* value::snap_load(const unsigned char* ptr, const loader& loader)
+	{
+		ptr = snap_read(ptr, _type);
+		ptr = snap_read(ptr, &bool_value, max_value_size);
+		if(_type == value_type::string) {
+			if(string_value.allocated) {
+				string_value.str = loader.string_table[(std::uintptr_t)(string_value.str)];
+			} else {
+				string_value.str = loader.story_string_table +(std::uintptr_t)(string_value.str);
+			}
+		}
+		return ptr;
+	}
 }

--- a/inkcpp/value.cpp
+++ b/inkcpp/value.cpp
@@ -76,7 +76,7 @@ namespace ink::runtime::internal
 		unsigned char* ptr = data;
 		ptr = snap_write(ptr, _type, data);
 		if (_type == value_type::string) {
-			unsigned char buf[max_value_size()];
+			unsigned char buf[max_value_size];
 			string_type* res = reinterpret_cast<string_type*>(buf);
 			auto str = get<value_type::string>();
 			res->allocated = str.allocated;
@@ -88,14 +88,14 @@ namespace ink::runtime::internal
 			ptr = snap_write(ptr, buf, data);
 		} else {
 			// TODO more space efficent?
-			ptr = snap_write(ptr, &bool_value, max_value_size(), data);
+			ptr = snap_write(ptr, &bool_value, max_value_size, data);
 		}
 		return ptr - data;
 	}
 	const unsigned char* value::snap_load(const unsigned char* ptr, const loader& loader)
 	{
 		ptr = snap_read(ptr, _type);
-		ptr = snap_read(ptr, &bool_value, max_value_size());
+		ptr = snap_read(ptr, &bool_value, max_value_size);
 		if(_type == value_type::string) {
 			if(string_value.allocated) {
 				string_value.str = loader.string_table[(std::uintptr_t)(string_value.str)];

--- a/inkcpp/value.cpp
+++ b/inkcpp/value.cpp
@@ -81,9 +81,9 @@ namespace ink::runtime::internal
 			auto str = get<value_type::string>();
 			res->allocated = str.allocated;
 			if (str.allocated) {
-				res->str = reinterpret_cast<const char*>(snapper.strings.get_id(str.str));
+				res->str = reinterpret_cast<const char*>(static_cast<std::uintptr_t>(snapper.strings.get_id(str.str)));
 			} else {
-				res->str = reinterpret_cast<const char*>(str.str - snapper.story_string_table);
+				res->str = reinterpret_cast<const char*>(static_cast<std::uintptr_t>(str.str - snapper.story_string_table));
 			}
 			ptr = snap_write(ptr, buf, data);
 		} else {

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -165,19 +165,7 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size =
-			sizeof_largest_type<
-				decltype(bool_value),
-				decltype(int32_value),
-				decltype(string_value),
-				decltype(uint32_value),
-				decltype(float_value),
-				decltype(jump),
-				decltype(list_value),
-				decltype(list_flag_value),
-				decltype(frame_value),
-				decltype(pointer)
-		>();
+		static constexpr size_t max_value_size() { return sizeof(value) - sizeof(value_type); }
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -165,7 +165,7 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size() { return sizeof(value) - sizeof(value_type); }
+		static constexpr size_t max_value_size() { return 128; }
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -92,7 +92,7 @@ namespace ink::runtime::internal {
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };
 
-		constexpr value() : _type{value_type::none}, bool_value{0}{}
+		constexpr value() : snapshot_interface(), _type{value_type::none}, bool_value{0}{}
 
 		/// get value of the type (if possible)
 		template<value_type ty>
@@ -165,7 +165,19 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size = 128;
+		static constexpr size_t max_value_size = 
+			sizeof_largest_type<
+				decltype(bool_value),
+				decltype(int32_value),
+				decltype(string_value),
+				decltype(uint32_value),
+				decltype(float_value),
+				decltype(jump),
+				decltype(list_value),
+				decltype(list_flag_value),
+				decltype(frame_value),
+				decltype(pointer)
+		>();
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -8,6 +8,7 @@
 #include "system.h"
 #include "../shared/private/command.h"
 #include "list_table.h"
+#include "snapshot_impl.h"
 #include "tuple.hpp"
 
 #ifdef INK_ENABLE_STL
@@ -82,8 +83,12 @@ namespace ink::runtime::internal {
 	/**
 	 * @brief class to wrap stack value to common type.
 	 */
-	class value {
+	class value : public snapshot_interface {
 	public:
+		// snapshot interface
+		size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
+
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -165,19 +165,7 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size =
-			sizeof_largest_type<
-				decltype(bool_value),
-				decltype(int32_value),
-				decltype(string_value),
-				decltype(uint32_value),
-				decltype(float_value),
-				decltype(jump),
-				decltype(list_value),
-				decltype(list_flag_value),
-				decltype(frame_value),
-				decltype(pointer)
-		>();
+		static constexpr size_t max_value_size() { return 120; }
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -93,6 +93,7 @@ namespace ink::runtime::internal {
 		template<value_type> struct ret { using type = void; };
 
 		constexpr value() : snapshot_interface(), _type{value_type::none}, bool_value{0}{}
+		constexpr explicit value( value_type type ) : _type{ type }, bool_value{0} {}
 
 		/// get value of the type (if possible)
 		template<value_type ty>
@@ -434,11 +435,11 @@ namespace ink::runtime::internal {
 
 	// static constexpr instantiations of flag values
 	namespace values {
-		static constexpr value marker = value{}.set<value_type::marker>();
-		static constexpr value glue = value{}.set<value_type::glue>();
-		static constexpr value newline = value{}.set<value_type::newline>();
-		static constexpr value func_start = value{}.set<value_type::func_start>();
-		static constexpr value func_end = value{}.set<value_type::func_end>();
-		static constexpr value null = value{}.set<value_type::null>();
+		static constexpr value marker = value( value_type::marker );
+		static constexpr value glue = value( value_type::glue );
+		static constexpr value newline = value( value_type::newline );
+		static constexpr value func_start = value( value_type::func_start );
+		static constexpr value func_end = value( value_type::func_end );
+		static constexpr value null = value( value_type::null );
 	}
 }

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -165,6 +165,19 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
+		static constexpr size_t max_value_size =
+			sizeof_largest_type<
+				decltype(bool_value),
+				decltype(int32_value),
+				decltype(string_value),
+				decltype(uint32_value),
+				decltype(float_value),
+				decltype(jump),
+				decltype(list_value),
+				decltype(list_flag_value),
+				decltype(frame_value),
+				decltype(pointer)
+		>();
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -87,7 +87,7 @@ namespace ink::runtime::internal {
 	public:
 		// snapshot interface
 		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
 
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -86,8 +86,8 @@ namespace ink::runtime::internal {
 	class value : public snapshot_interface {
 	public:
 		// snapshot interface
-		size_t snap(unsigned char* data, const snapper&) const;
-		const unsigned char* snap_load(const unsigned char* data, const loader&);
+		size_t snap(unsigned char* data, const snapper&) const override;
+		const unsigned char* snap_load(const unsigned char* data, const loader&) override { inkAssert(false, "not implemented yet!"); return nullptr; }
 
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -165,7 +165,7 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size() { return 120; }
+		static constexpr size_t max_value_size = 128;
 		value_type _type;
 	};
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -92,7 +92,7 @@ namespace ink::runtime::internal {
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };
 
-		constexpr value() : _type{value_type::none}, uint32_value{0}{}
+		constexpr value() : _type{value_type::none}, bool_value{0}{}
 
 		/// get value of the type (if possible)
 		template<value_type ty>
@@ -165,7 +165,19 @@ namespace ink::runtime::internal {
 				char ci;
 			} pointer;
 		};
-		static constexpr size_t max_value_size() { return 128; }
+		static constexpr size_t max_value_size =
+			sizeof_largest_type<
+				decltype(bool_value),
+				decltype(int32_value),
+				decltype(string_value),
+				decltype(uint32_value),
+				decltype(float_value),
+				decltype(jump),
+				decltype(list_value),
+				decltype(list_flag_value),
+				decltype(frame_value),
+				decltype(pointer)
+		>();
 		value_type _type;
 	};
 

--- a/inkcpp_cl/inkcpp_cl.cpp
+++ b/inkcpp_cl/inkcpp_cl.cpp
@@ -20,7 +20,7 @@ void usage()
 	cout
 		<< "Usage: inkcpp_cl <options> <json file>\n"
 		<< "\t-o <filename>:\tOutput file name\n"
-		<< "\t-p [<snapshot_file>]:\tPlay mode\n\toptional snapshot file to load\n"
+		<< "\t-p [<snapshot_file>]:\tPlay mode\n\toptional snapshot file to load\n\tto create a snapshot file enter '-1' as choice\n"
 		<< endl;
 }
 
@@ -181,8 +181,7 @@ int main(int argc, const char** argv)
 				std::cin >> c;
 				if (c == -1) {
 					snapshot* snap = thread->create_snapshot();
-					// snap->write_to_file("test.snap");
-					snap->write_to_file("test.snap");
+					snap->write_to_file(std::regex_replace(inputFilename, std::regex("\\.[^\\.]+$"), ".snap").c_str());
 					break;
 				}
 				thread->choose(c - 1);

--- a/inkcpp_cl/inkcpp_cl.cpp
+++ b/inkcpp_cl/inkcpp_cl.cpp
@@ -148,9 +148,10 @@ int main(int argc, const char** argv)
 		// Start runner
 		runner thread;
 		if (snapshotFile.size()) {
-			globals	glob = myInk->new_globals_from_snapshot(*snapshot::from_file(snapshotFile.c_str()));
+			thread = myInk->new_runner_from_snapshot(*snapshot::from_file(snapshotFile.c_str()));
+		} else {
+			thread = myInk->new_runner();
 		}
-		thread = myInk->new_runner();
 
 		while (true)
 		{

--- a/inkcpp_cl/inkcpp_cl.cpp
+++ b/inkcpp_cl/inkcpp_cl.cpp
@@ -177,6 +177,8 @@ int main(int argc, const char** argv)
 			break;
 		}
 
+		delete myInk;
+
 		return 0;
 	}
 	catch (const std::exception& e)

--- a/inkcpp_compiler/binary_emitter.cpp
+++ b/inkcpp_compiler/binary_emitter.cpp
@@ -67,9 +67,9 @@ namespace ink::compiler::internal
 
 			// Clear lists
 			children.clear();
-			named_children.clear();
-			indexed_children.clear();
-			noop_offsets.clear();
+			//named_children.clear();
+			//indexed_children.clear();
+			//noop_offsets.clear();
 			parent = nullptr;
 		}
 	};

--- a/inkcpp_test/NewLines.cpp
+++ b/inkcpp_test/NewLines.cpp
@@ -2,6 +2,7 @@
 #include "../inkcpp_cl/test.h"
 
 #include <story.h>
+#include <globals.h>
 #include <runner.h>
 #include <compiler.h>
 


### PR DESCRIPTION
a snapshot contains all data which are not contained in the story and are
neccessary to restore the current state. Because of that a snapshot contains
a global and all corresponding runners.

- For loading a snapshot the same story file must be loaded
- functions must be bind again after loading a snapshot

further notes:
- add new `snapshot_interface` to implement for not trivial data types
- implement `runner_create_snapshot` and `globals_create_snapshot`
- implement `snapshot` interface for access from user
- implement writing snapshot to file and reading it from file
- add `new_globals_from_snapshot` and `new_runner_from_snapshot` for story
- updated wiki

