### PR TITLE
Fallback for external functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Many, but not all features of the Ink language are supported (see Glaring Omissi
 * Visit and read counts (`visits` and `CNT?` commands).
 * `seq` command and all sequence types (stopping, cycle, shuffle)
 * Global store that can be shared between runners
-* External function binding (no fallback support yet)
+* External function binding (define a function with same signature and name, which will be used if no function is bindeded)
 * Tunnels and internal functions
 * Ink threads (probably incredibly unstable though)
 

--- a/inkcpp/functional.cpp
+++ b/inkcpp/functional.cpp
@@ -32,6 +32,12 @@ namespace ink::runtime::internal
 		stack->push(value{}.set<value_type::int32>(v));
 	}
 
+	void function_base::push_void(basic_eval_stack* stack)
+	{
+		stack->push(values::null);
+	}
+
+
 	void function_base::push_string(basic_eval_stack* stack, const char* dynamic_string)
 	{
 		stack->push(value{}.set<value_type::string>(dynamic_string, true));

--- a/inkcpp/include/functional.h
+++ b/inkcpp/include/functional.h
@@ -26,6 +26,8 @@ namespace ink::runtime::internal
 		template<typename T>
 		static void push(basic_eval_stack* stack, const T& value);
 
+		static void push_void(basic_eval_stack* stack);
+
 		// string special push
 		static void push_string(basic_eval_stack* stack, const char* dynamic_string);
 
@@ -81,7 +83,7 @@ namespace ink::runtime::internal
 				
 				// Ink expects us to push something
 				// TODO -- Should be a special "void" value
-				push(stack, 0);
+				push_void(stack);
 			}
 			else if constexpr (is_string<typename traits::return_type>::value)
 			{

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -646,7 +646,7 @@ namespace ink::runtime::internal
 			Command cmd = read<Command>();
 			CommandFlag flag = read<CommandFlag>();
 
-			if (cmd == Command::FUNCTION && _eval.top_value().type() == value_type::ex_fn_not_found) {
+			if (!_eval.is_empty() && _eval.top().type() == value_type::ex_fn_not_found) {
 				inkAssert(cmd == Command::FUNCTION, "Failed to call external function and no "
 					"local function exists to call instead! Please bind external function or "
 					"add define a dummy function in your story!"
@@ -857,6 +857,7 @@ namespace ink::runtime::internal
 				if (!(flag & CommandFlag::FALLBACK_FUNCTION)) {
 					start_frame<frame_type::function>(target);
 				} else {
+					inkAssert(!_eval.is_empty(), "fallback function but no function call before?");
 					if(_eval.top_value().type() == value_type::ex_fn_not_found) {
 						_eval.pop();
 						start_frame<frame_type::function>(target);

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -646,7 +646,7 @@ namespace ink::runtime::internal
 			Command cmd = read<Command>();
 			CommandFlag flag = read<CommandFlag>();
 
-			if (_eval->top_value().type() == value_type::ex_fn_not_found) {
+			if (cmd == Command::FUNCTION && _eval.top_value().type() == value_type::ex_fn_not_found) {
 				inkAssert(cmd == Command::FUNCTION, "Failed to call external function and no "
 					"local function exists to call instead! Please bind external function or "
 					"add define a dummy function in your story!"

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -6,8 +6,6 @@
 #include "header.h"
 #include "string_utils.h"
 
-#include <iostream>
-
 namespace ink::runtime
 {
 	const choice* runner_interface::get_choice(size_t index) const
@@ -933,7 +931,6 @@ namespace ink::runtime::internal
 				// If we failed, notify a potential fallback function
 				if (!success)
 				{
-					std::cout << "ex_fn_not_found" << static_cast<int>(value_type::ex_fn_not_found) << "\n";
 					_eval.push(values::ex_fn_not_found);
 				}
 			}

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -6,6 +6,8 @@
 #include "header.h"
 #include "string_utils.h"
 
+#include <iostream>
+
 namespace ink::runtime
 {
 	const choice* runner_interface::get_choice(size_t index) const
@@ -646,13 +648,6 @@ namespace ink::runtime::internal
 			Command cmd = read<Command>();
 			CommandFlag flag = read<CommandFlag>();
 
-			if (!_eval.is_empty() && _eval.top().type() == value_type::ex_fn_not_found) {
-				inkAssert(cmd == Command::FUNCTION, "Failed to call external function and no "
-					"local function exists to call instead! Please bind external function or "
-					"add define a dummy function in your story!"
-				);
-			}
-
 			// If we're falling and we hit a non-fallthrough command, stop the fall.
 			if (_is_falling && !((cmd == Command::DIVERT && flag & CommandFlag::DIVERT_IS_FALLTHROUGH) || cmd == Command::END_CONTAINER_MARKER))
 			{
@@ -860,6 +855,7 @@ namespace ink::runtime::internal
 					inkAssert(!_eval.is_empty(), "fallback function but no function call before?");
 					if(_eval.top_value().type() == value_type::ex_fn_not_found) {
 						_eval.pop();
+						inkAssert(target != 0, "Exetrnal function was not binded, and no fallback function provided!");
 						start_frame<frame_type::function>(target);
 					}
 				}
@@ -937,6 +933,7 @@ namespace ink::runtime::internal
 				// If we failed, notify a potential fallback function
 				if (!success)
 				{
+					std::cout << "ex_fn_not_found" << static_cast<int>(value_type::ex_fn_not_found) << "\n";
 					_eval.push(values::ex_fn_not_found);
 				}
 			}
@@ -1135,6 +1132,7 @@ namespace ink::runtime::internal
 				inkAssert(false, "Unrecognized command!");
 				break;
 			}
+
 		}
 		catch (...)
 		{

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -612,9 +612,6 @@ namespace ink::runtime::internal
 			// If we're on a newline
 			if (_output.ends_with(value_type::newline))
 			{
-				// TODO: REMOVE
-				// return true;
-
 				// Unless we are out of content, we are going to try
 				//  to continue a little further. This is to check for
 				//  glue (which means there is potentially more content
@@ -850,7 +847,13 @@ namespace ink::runtime::internal
 				} else {
 					target = read<uint32_t>();
 				}
-				start_frame<frame_type::function>(target);
+				if (!(flag & CommandFlag::FALLBACK_FUNCTION)) {
+					start_frame<frame_type::function>(target);
+				} else {
+					if(_eval.top_value().type() == value_type::ex_fn_not_found) {
+						start_frame<frame_type::function>(target);
+					}
+				}
 			}
 			break;
 			case Command::TUNNEL_RETURN:
@@ -930,7 +933,7 @@ namespace ink::runtime::internal
 						_eval.pop();
 
 					// push void
-					_eval.push(value());
+					_eval.push(values::ex_fn_not_found);
 				}
 
 				// TODO: Verify something was found?

--- a/inkcpp/stack.cpp
+++ b/inkcpp/stack.cpp
@@ -1,8 +1,6 @@
 #include "stack.h"
 #include "string_table.h"
 
-#include <iostream>
-
 namespace ink::runtime::internal
 {
 	basic_stack::basic_stack(entry* data, size_t size)
@@ -506,7 +504,6 @@ namespace ink::runtime::internal
 
 	void basic_eval_stack::push(const value& val)
 	{
-		std::cout << "push" << static_cast<int>(val.type()) << "\n";
 		base::push(val);
 	}
 

--- a/inkcpp/stack.cpp
+++ b/inkcpp/stack.cpp
@@ -1,6 +1,8 @@
 #include "stack.h"
 #include "string_table.h"
 
+#include <iostream>
+
 namespace ink::runtime::internal
 {
 	basic_stack::basic_stack(entry* data, size_t size)
@@ -504,6 +506,7 @@ namespace ink::runtime::internal
 
 	void basic_eval_stack::push(const value& val)
 	{
+		std::cout << "push" << static_cast<int>(val.type()) << "\n";
 		base::push(val);
 	}
 

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -41,6 +41,7 @@ namespace ink::runtime::internal {
 		func_start,                 // start of function marker
 		func_end,                   // end of function marker
 		null,                       // void value, for function returns
+		ex_fn_not_found,			// value for failed external function calls
 		tunnel_frame,               // return from tunnel
 		function_frame,             // return from function
 		thread_frame,               // return from thread
@@ -351,6 +352,11 @@ namespace ink::runtime::internal {
 		return *this;
 	}
 	template<>
+	inline constexpr value& value::set<value_type::ex_fn_not_found>() {
+		_type = value_type::ex_fn_not_found;
+		return *this;
+	}
+	template<>
 	inline constexpr value& value::set<value_type::newline>() {
 		_type = value_type::newline;
 		return *this;
@@ -418,6 +424,7 @@ namespace ink::runtime::internal {
 	namespace values {
 		static constexpr value marker = value{}.set<value_type::marker>();
 		static constexpr value glue = value{}.set<value_type::glue>();
+		static constexpr value ex_fn_not_found = value{}.set<value_type::ex_fn_not_found>();
 		static constexpr value newline = value{}.set<value_type::newline>();
 		static constexpr value func_start = value{}.set<value_type::func_start>();
 		static constexpr value func_end = value{}.set<value_type::func_end>();

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -41,7 +41,7 @@ namespace ink::runtime::internal {
 		func_start,                 // start of function marker
 		func_end,                   // end of function marker
 		null,                       // void value, for function returns
-		ex_fn_not_found,			// value for failed external function calls
+		ex_fn_not_found,						// value for failed external function calls
 		tunnel_frame,               // return from tunnel
 		function_frame,             // return from function
 		thread_frame,               // return from thread

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -41,7 +41,7 @@ namespace ink::runtime::internal {
 		func_start,                 // start of function marker
 		func_end,                   // end of function marker
 		null,                       // void value, for function returns
-		ex_fn_not_found,						// value for failed external function calls
+		ex_fn_not_found,            // value for failed external function calls
 		tunnel_frame,               // return from tunnel
 		function_frame,             // return from function
 		thread_frame,               // return from thread

--- a/inkcpp_compiler/binary_emitter.cpp
+++ b/inkcpp_compiler/binary_emitter.cpp
@@ -12,8 +12,6 @@
 #include <cstring>
 #endif
 
-#include <iostream>
-
 namespace ink::compiler::internal
 {
 	using std::vector;
@@ -109,7 +107,6 @@ namespace ink::compiler::internal
 			_current->indexed_children.insert({ index_in_parent, container });
 
 			if (!name.empty()) {
-				std::cout << "add: " << name << "\n";
 				_current->named_children.insert({ name, container });
 			}
 		}
@@ -132,12 +129,9 @@ namespace ink::compiler::internal
 
    	int binary_emitter::function_container_arguments(const std::string& name)
 	{
-		std::cout << "a\n";
 		if(_root == nullptr) { return -1; }
-		std::cout << "b\n";
 		auto fn = _root->named_children.find(name);
 		if (fn == _root->named_children.end()) { return -1; }
-		std::cout << "c\n";
 
 		size_t offset = fn->second->offset;
 		byte_t cmd = _containers.get(offset);
@@ -166,7 +160,6 @@ namespace ink::compiler::internal
 		// Note the position of this later so we can resolve the paths at the end
 		size_t param_position = _containers.pos() - sizeof(uint32_t);
 		bool op = flag & CommandFlag::FALLBACK_FUNCTION;
-		if(op) std::cout << "op\n";
 		_paths.push_back(std::make_tuple(param_position, path, op, _current, useCountIndex));
 	}
 
@@ -381,9 +374,7 @@ namespace ink::compiler::internal
 					// Otherwise, write container address
 					if (container == nullptr) {
 						_containers.set(position, 0);
-						std::cout << "optional: ? " << optional << "\n";
-						std::cout << path << "\n";
-						inkAssert(optional, "Was not able to resolve a not optional path!");
+						inkAssert(optional, ("Was not able to resolve a not optional path! '" + path + "'").c_str());
 					} else {
 						_containers.set(position, container->offset);
 					}

--- a/inkcpp_compiler/binary_emitter.cpp
+++ b/inkcpp_compiler/binary_emitter.cpp
@@ -17,7 +17,6 @@ namespace ink::compiler::internal
 	using std::vector;
 	using std::map;
 	using std::string;
-	using std::tuple;
 
 	char* strtok_s(char * s, const char * sep, char** context) {
 #if defined(_WIN32) || defined(_WIN64)
@@ -125,6 +124,23 @@ namespace ink::compiler::internal
 
 		// Return offset
 		return _containers.pos();
+	}
+
+   	int binary_emitter::function_container_arguments(const std::string& name)
+	{
+		if(_root == nullptr) { return -1; }
+		auto fn = _root->named_children.find(name);
+		if (fn == _root->named_children.end()) { return -1; }
+
+		size_t offset = fn->second->offset;
+		byte_t cmd = _containers.get(offset);
+		int arity = 0;
+		while(static_cast<Command>(cmd) == Command::DEFINE_TEMP) {
+			offset += 6; // command(1) + flag(1) + variable_name_hash(4)
+			cmd = _containers.get(offset);
+			++arity;		  
+		}
+		return arity;
 	}
 
 	void binary_emitter::write_raw(Command command, CommandFlag flag, const char* payload, ink::size_t payload_size)

--- a/inkcpp_compiler/binary_emitter.h
+++ b/inkcpp_compiler/binary_emitter.h
@@ -54,6 +54,11 @@ namespace ink::compiler::internal
 		binary_stream _lists;
 		binary_stream _containers;
 
-		std::vector<std::tuple<size_t, std::string, container_data*, bool>> _paths;
+		// positon to write address
+		// path as string
+		// if path may not exists (used for function fallbackes)
+		// container data
+		// use count index?
+		std::vector<std::tuple<size_t, std::string, bool, container_data*, bool>> _paths;
 	};
 }

--- a/inkcpp_compiler/binary_emitter.h
+++ b/inkcpp_compiler/binary_emitter.h
@@ -18,6 +18,7 @@ namespace ink::compiler::internal
 		// Begin emitter
 		virtual uint32_t start_container(int index_in_parent, const std::string& name) override;
 		virtual uint32_t end_container() override;
+		virtual int function_container_arguments(const std::string& name) override;
 		virtual void write_raw(Command command, CommandFlag flag = CommandFlag::NO_FLAGS, const char* payload = nullptr, ink::size_t payload_size = 0) override;
 		virtual void write_path(Command command, CommandFlag flag, const std::string& path, bool useCountIndex = false) override;
 		virtual void write_variable(Command command, CommandFlag flag, const std::string& name) override;

--- a/inkcpp_compiler/binary_stream.cpp
+++ b/inkcpp_compiler/binary_stream.cpp
@@ -124,6 +124,23 @@ namespace ink
 				memcpy(ptr, data, len);
 			}
 
+			byte_t binary_stream::get(size_t offset) const
+			{
+				// Find slab for offset
+				unsigned int slab_index = offset / DATA_SIZE;
+				size_t pos = offset % DATA_SIZE;
+
+				// Get slab and ptr
+				byte_t* slab = nullptr;
+				if (slab_index < _slabs.size())
+					slab = _slabs[slab_index];
+				else if (slab_index == _slabs.size())
+					slab = _currentSlab;
+
+				inkAssert(slab != nullptr, "try to access invalid slab in binary stream");
+				return slab[pos];
+			}
+
 			void binary_stream::reset()
 			{
 				// Delete all slabs

--- a/inkcpp_compiler/binary_stream.h
+++ b/inkcpp_compiler/binary_stream.h
@@ -48,6 +48,9 @@ namespace ink
 				// reset to 0
 				void reset();
 
+				// read a byte from stream
+				byte_t get(size_t offset) const;
+
 			private:
 				// Size of a data slab. Whenever
 				//  a slab runs out of data,

--- a/inkcpp_compiler/emitter.h
+++ b/inkcpp_compiler/emitter.h
@@ -28,6 +28,12 @@ namespace ink::compiler::internal
 		// ends a container
 		virtual uint32_t end_container() = 0;
 
+		// checks if _root contains a container named name to check
+		// if name is in valid internal function name
+		// @return number of arguments functions takes (arity)
+		// @retval -1 if the function was not found
+		virtual int function_container_arguments(const std::string& name) = 0;
+
 		// Writes a command with an optional payload
 		virtual void write_raw(Command command, CommandFlag flag = CommandFlag::NO_FLAGS, const char* payload = nullptr, ink::size_t payload_size = 0) = 0;
 

--- a/inkcpp_compiler/json_compiler.cpp
+++ b/inkcpp_compiler/json_compiler.cpp
@@ -364,8 +364,16 @@ namespace ink::compiler::internal
 			// Encode argument count into command flag and write out the hash of the function name
 			_emitter->write(Command::CALL_EXTERNAL, hash_string(val.c_str()),
 					static_cast<CommandFlag>(numArgs));
-			_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
-		}
+			// if internal function with same name exists 
+			int arity = _emitter->function_container_arguments(val);
+			if (arity >= 0) {
+				inkAssert(arity == numArgs,
+					("fallback function for '" + val + "' takes " + std::to_string(arity) +
+					" but the external function is supposed to take " + std::to_string(numArgs) 
+					+ " arguments.").c_str()
+				);
+				_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
+			}		}
 
 		// list initialisation
 		else if (has(command, "list"))

--- a/inkcpp_compiler/json_compiler.cpp
+++ b/inkcpp_compiler/json_compiler.cpp
@@ -121,6 +121,7 @@ namespace ink::compiler::internal
 		const nlohmann::json& container, int index_in_parent,
 		const std::string& name_override)
 	{
+		std::cout << "compile: " << name_override << "\n";
 		// Grab metadata from the last object in this container
 		container_meta meta;
 		handle_container_metadata(*container.rbegin(), meta);
@@ -357,6 +358,7 @@ namespace ink::compiler::internal
 		// External function call
 		else if (get(command, "x()", val))
 		{
+			std::cout << "fallback\n";
 			// Get argument count
 			int numArgs = 0;
 			get(command, "exArgs", numArgs);
@@ -364,16 +366,20 @@ namespace ink::compiler::internal
 			// Encode argument count into command flag and write out the hash of the function name
 			_emitter->write(Command::CALL_EXTERNAL, hash_string(val.c_str()),
 					static_cast<CommandFlag>(numArgs));
-			// if internal function with same name exists 
-			int arity = _emitter->function_container_arguments(val);
-			if (arity >= 0) {
-				inkAssert(arity == numArgs,
-					("fallback function for '" + val + "' takes " + std::to_string(arity) +
-					" but the external function is supposed to take " + std::to_string(numArgs) 
-					+ " arguments.").c_str()
-				);
 				_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
-			}		}
+			// if internal function with same name exists 
+			// int arity = _emitter->function_container_arguments(val);
+			// std::cout << "arity: " << arity << "\n";
+			// if (arity >= 0) {
+			// 	inkAssert(arity == numArgs,
+			// 		("fallback function for '" + val + "' takes " + std::to_string(arity) +
+			// 		" but the external function is supposed to take " + std::to_string(numArgs) 
+			// 		+ " arguments.").c_str()
+			// 	);
+			// 	std::cout << "write fallback\n";
+			// 	_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
+			// }
+		}
 
 		// list initialisation
 		else if (has(command, "list"))

--- a/inkcpp_compiler/json_compiler.cpp
+++ b/inkcpp_compiler/json_compiler.cpp
@@ -121,7 +121,6 @@ namespace ink::compiler::internal
 		const nlohmann::json& container, int index_in_parent,
 		const std::string& name_override)
 	{
-		std::cout << "compile: " << name_override << "\n";
 		// Grab metadata from the last object in this container
 		container_meta meta;
 		handle_container_metadata(*container.rbegin(), meta);
@@ -358,7 +357,6 @@ namespace ink::compiler::internal
 		// External function call
 		else if (get(command, "x()", val))
 		{
-			std::cout << "fallback\n";
 			// Get argument count
 			int numArgs = 0;
 			get(command, "exArgs", numArgs);
@@ -366,20 +364,8 @@ namespace ink::compiler::internal
 			// Encode argument count into command flag and write out the hash of the function name
 			_emitter->write(Command::CALL_EXTERNAL, hash_string(val.c_str()),
 					static_cast<CommandFlag>(numArgs));
-				_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
-			// if internal function with same name exists 
-			// int arity = _emitter->function_container_arguments(val);
-			// std::cout << "arity: " << arity << "\n";
-			// if (arity >= 0) {
-			// 	inkAssert(arity == numArgs,
-			// 		("fallback function for '" + val + "' takes " + std::to_string(arity) +
-			// 		" but the external function is supposed to take " + std::to_string(numArgs) 
-			// 		+ " arguments.").c_str()
-			// 	);
-			// 	std::cout << "write fallback\n";
-			// 	_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
-			// }
-		}
+			_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
+	}
 
 		// list initialisation
 		else if (has(command, "list"))

--- a/inkcpp_compiler/json_compiler.cpp
+++ b/inkcpp_compiler/json_compiler.cpp
@@ -364,6 +364,7 @@ namespace ink::compiler::internal
 			// Encode argument count into command flag and write out the hash of the function name
 			_emitter->write(Command::CALL_EXTERNAL, hash_string(val.c_str()),
 					static_cast<CommandFlag>(numArgs));
+			_emitter->write_path(Command::FUNCTION, CommandFlag::FALLBACK_FUNCTION, val);
 		}
 
 		// list initialisation

--- a/inkcpp_test/CMakeLists.txt
+++ b/inkcpp_test/CMakeLists.txt
@@ -1,15 +1,16 @@
 add_executable(inkcpp_test catch.hpp Main.cpp 
-    Array.cpp 
-    Pointer.cpp 
-    Stack.cpp
-    Callstack.cpp
-    Restorable.cpp
-	Value.cpp
-	Globals.cpp
-	Lists.cpp
-	Tags.cpp
-	NewLines.cpp
-    )
+  Array.cpp
+  Pointer.cpp
+  Stack.cpp
+  Callstack.cpp
+  Restorable.cpp
+  Value.cpp
+  Globals.cpp
+  Lists.cpp
+  Tags.cpp
+  NewLines.cpp
+  FallbackFunction.cpp
+)
 
 target_link_libraries(inkcpp_test PUBLIC inkcpp inkcpp_compiler inkcpp_shared)
 target_include_directories(inkcpp_test PRIVATE ../shared/private/)

--- a/inkcpp_test/FallbackFunction.cpp
+++ b/inkcpp_test/FallbackFunction.cpp
@@ -50,7 +50,7 @@ SCENARIO("run a story with external function and fallback function", "[external 
       REQUIRE_NOTHROW(out = thread->getall());;
       THEN("Sqrt should be falled twice, and uses default greeting")
       {
-        REQUIRE(out == "oho");
+        REQUIRE(out == "Hello ! A small demonstraion of my power:\n4 * 4 = 16, stunning i would say\n");
         REQUIRE(cnt_sqrt == 2);
       }
     }

--- a/inkcpp_test/FallbackFunction.cpp
+++ b/inkcpp_test/FallbackFunction.cpp
@@ -1,0 +1,63 @@
+#include "catch.hpp"
+#include "../inkcpp_cl/test.h"
+
+#include <system.h>
+#include <story.h>
+#include <runner.h>
+#include <globals.h>
+#include <compiler.h>
+
+#include <cmath>
+
+using namespace ink::runtime;
+
+SCENARIO("run a story with external function and fallback function", "[external function]")
+{
+  GIVEN("story with two external functions, one with fallback")
+  {
+    inklecate("ink/FallBack.ink", "FallBack.tmp");
+    ink::compiler::run("FallBack.tmp", "FallBack.bin");
+    auto ink = story::from_file("FallBack.bin");
+    runner thread = ink->new_runner();
+    
+    WHEN("bind both external functions")
+    {
+      int cnt_sqrt = 0;
+      auto fn_sqrt = [&cnt_sqrt](int x)->int{ ++cnt_sqrt; return sqrt(x); };
+      int cnt_greeting = 0;
+      auto fn_greeting = [&cnt_greeting]()->const char*{++cnt_greeting; return "Hohooh"; };
+      
+      thread->bind("sqrt", fn_sqrt);
+      thread->bind("greeting", fn_greeting);
+      
+      std::string out;
+      REQUIRE_NOTHROW(out = thread->getall());
+      THEN("Both function should be called the correct amount of times")
+      {
+        REQUIRE(out == "Hohooh ! A small demonstraion of my power:\n4 * 4 = 16, stunning i would say\n");
+        REQUIRE(cnt_sqrt == 2);
+        REQUIRE(cnt_greeting == 1);
+      }
+    }
+    WHEN("only bind function without fallback")
+    {
+      int cnt_sqrt = 0;
+      auto fn_sqrt = [&cnt_sqrt](int x)->int{++cnt_sqrt; return sqrt(x); };
+      
+      thread ->bind("sqrt", fn_sqrt);
+      
+      std::string out;
+      REQUIRE_NOTHROW(out = thread->getall());;
+      THEN("Sqrt should be falled twice, and uses default greeting")
+      {
+        REQUIRE(out == "oho");
+        REQUIRE(cnt_sqrt == 2);
+      }
+    }
+    WHEN("bind no function")
+    {
+      std::string out;
+      REQUIRE_THROWS_AS(out = thread->getall(), ink::ink_exception);
+    }
+  }
+}

--- a/inkcpp_test/NewLines.cpp
+++ b/inkcpp_test/NewLines.cpp
@@ -2,6 +2,7 @@
 #include "../inkcpp_cl/test.h"
 
 #include <story.h>
+#include <globals.h>
 #include <runner.h>
 #include <compiler.h>
 

--- a/inkcpp_test/ink/FallBack.ink
+++ b/inkcpp_test/ink/FallBack.ink
@@ -1,0 +1,13 @@
+-> Start
+
+EXTERNAL sqrt(x)
+
+EXTERNAL greeting()
+
+=== function greeting() ===
+~ return "Hello"
+
+== Start ==
+{greeting()} ! A small demonstraion of my power:
+{sqrt(16)} * {sqrt(16)} = 16, stunning i would say
+-> DONE

--- a/shared/private/command.h
+++ b/shared/private/command.h
@@ -140,6 +140,8 @@ namespace ink
 		// == Function/Tunnel flags
 		FUNCTION_TO_VARIABLE = 1 << 0,
 		TUNNEL_TO_VARIABLE = 1 << 0,
+		FALLBACK_FUNCTION = 1 << 1,
+		// note a internal function which should only be called if external reference is not working
 	};
 
 	inline bool operator& (CommandFlag lhs, CommandFlag rhs)


### PR DESCRIPTION
Add fallback for external functions

based on:
https://github.com/inkle/ink/blob/master/Documentation/RunningYourInk.md#fallbacks-for-external-functions

It is now possible to implement a dummy/error function for each external
functions. It must have been the same name and same number of arguments
and will be executed if the external function was not bind when needed.
IF the external functions will get bind later, then it will be called
the next time.

Introduces new flag: `FALLBACK_FUNCTION` to add a new execution
dimension
Introduce new value type: `ex_fn_not_found` to signal failed external
