### PR TITLE
Fix Line distribution with function calls

### DIFF
--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -578,8 +578,7 @@ namespace ink::runtime::internal
 		if (hasAddedNewText)
 			return change_type::extended_past_newline;
 
-		// Nothing to report yet
-		return change_type::no_change;
+		inkFail("Invalid change detction. Never should be here!");
 	}
 
 	bool runner_impl::line_step()
@@ -606,7 +605,6 @@ namespace ink::runtime::internal
 					forget();
 					break;
 				case change_type::no_change:
-					forget();
 					break;
 				}
 			}
@@ -625,8 +623,8 @@ namespace ink::runtime::internal
 				{
 					// Save a snapshot of the current runtime state so we
 					//  can return here if we end up hitting a new line
-					if (!_saved)
-						save();
+					forget();
+					save();
 				}
 				// Otherwise, make sure we don't have any snapshots hanging around
 				// expect we are in choice handleing

--- a/inkcpp_test/NewLines.cpp
+++ b/inkcpp_test/NewLines.cpp
@@ -34,6 +34,29 @@ SCENARIO("a story has the proper line breaks", "[lines]")
 					REQUIRE(line3 == "Line 3\n");
 					REQUIRE(line4 == "Line 4\n");
 				}
+			}
+			WHEN("consume lines with functions")
+			{
+				thread->move_to(ink::hash_string("Functions"));
+				std::string line1 = thread->getline();
+				std::string line2 = thread->getline();
+
+				THEN("function lines are correct") {
+					REQUIRE(line1 == "Function Line\n");
+					REQUIRE(line2 == "Function Result\n");
+				}
+			}
+			WHEN("consume lines with tunnels")
+			{
+				thread->move_to(ink::hash_string("Tunnels"));
+				std::string line1 = thread->getline();
+				std::string line2 = thread->getline();
+
+				THEN("tunnel lines are correct") {
+					REQUIRE(line1 == "Tunnel Line\n");
+					REQUIRE(line2 == "Tunnel Result\n");
+				}
+
 				THEN("thread cannot continue")
 				{
 					REQUIRE(!thread->can_continue());

--- a/inkcpp_test/ink/LinesStory.ink
+++ b/inkcpp_test/ink/LinesStory.ink
@@ -15,3 +15,28 @@ Line 3
 Line 4
 
 -> DONE
+
+== Functions ==
+Function Line
+
+~ funcTest()
+
+-> DONE
+
+== Tunnels ==
+Tunnel Line
+
+-> tunnel_test ->
+
+-> DONE
+
+
+=== function funcTest()
+Function Result
+
+
+== tunnel_test
+
+Tunnel Result
+
+->->


### PR DESCRIPTION
Function calls dont split lines correct.

Assumed problem a miss managment with no_change operations

Fix recomandet in https://github.com/brwarner/inkcpp/issues/44#issuecomment-1189681843 leads to wrong visit counts, since nodes visited by look aheads are not forgetten correctly



closes #45

