### PR TITLE
inkcpp_cl: Fix spaces in path name failing with Inklecate

### DIFF
--- a/inkcpp_cl/test.cpp
+++ b/inkcpp_cl/test.cpp
@@ -21,7 +21,7 @@ void inklecate(const std::string& inkFilename, const std::string& jsonFilename)
 
 	// Create command
 	std::stringstream cmd;
-	cmd << inklecateCmd << " -o " << jsonFilename << " " << inkFilename;
+	cmd << inklecateCmd << " -o \"" << jsonFilename << "\" \"" << inkFilename << "\"";
 
 	// Run
 	int result = std::system(cmd.str().c_str());


### PR DESCRIPTION
Currently, a filepath with a space in it causes an error, because the path is handed to `inklecate.exe` raw from the input arguments, without quotes around it. This PR adds quotes to the `inklecate.exe` call, allowing any valid path to work.