### PR TITLE
Fix: added restoarble tags

### DIFF
--- a/inkcpp/array.h
+++ b/inkcpp/array.h
@@ -94,9 +94,9 @@ namespace ink::runtime::internal {
 			unsigned char* ptr          = data;
 			bool           should_write = data != nullptr;
 			ptr                         = snap_write( ptr, _size, should_write );
-			for ( const T& e : *this )
+			for (const T& e : *this)
 			{
-				if constexpr (is_base_of<snapshot_interface, typename remove_cvref<decltype(e)>::type>::value) {
+				if constexpr (is_base_of<snapshot_interface, T>::value) {
 					ptr += e.snap(data == nullptr ? nullptr : ptr, snapper);
 				} else {
 					ptr = snap_write( ptr, e, should_write );
@@ -119,7 +119,7 @@ namespace ink::runtime::internal {
 			}
 			for ( T& e : *this )
 			{
-				if constexpr (is_base_of<snapshot_interface, typename remove_cvref<decltype(e)>::type>::value) {
+				if constexpr (is_base_of<snapshot_interface, T>::value) {
 					ptr = e.snap_load(ptr, loader);
 				} else {
 					ptr = snap_read( ptr, e );

--- a/inkcpp/array.h
+++ b/inkcpp/array.h
@@ -1,149 +1,240 @@
 #pragma once
 
+#include "snapshot_interface.h"
 #include "system.h"
 #include "traits.h"
-#include "snapshot_interface.h"
 
-namespace ink::runtime::internal
-{
+namespace ink::runtime::internal {
 	template<typename T, bool dynamic, size_t initialCapacity>
-		class managed_array : snapshot_interface {
+	class managed_array : public snapshot_interface
+	{
 	public:
-		managed_array() : _static_data{}, _capacity{ initialCapacity }, _size{ 0 }{
-			if constexpr (dynamic) {
+		managed_array()
+		 : _static_data{},
+		   _capacity{ initialCapacity },
+		   _size{ 0 }
+		{
+			if constexpr ( dynamic )
+			{
 				_dynamic_data = new T[initialCapacity];
 			}
 		}
 
-		const T& operator[](size_t i) const { return data()[i]; }
-		T& operator[](size_t i) { return data()[i]; }
-		const T* data() const {
-			if constexpr (dynamic) {
+		const T& operator[]( size_t i ) const { return data()[i]; }
+		T&       operator[]( size_t i ) { return data()[i]; }
+		const T* data() const
+		{
+			if constexpr ( dynamic )
+			{
 				return _dynamic_data;
-			} else {
+			}
+			else
+			{
 				return _static_data;
 			}
 		}
-		T* data() {
-			if constexpr (dynamic) {
+		T* data()
+		{
+			if constexpr ( dynamic )
+			{
 				return _dynamic_data;
-			} else {
+			}
+			else
+			{
 				return _static_data;
 			}
 		}
 		const T* begin() const { return data(); }
-		T* begin() { return data(); }
+		T*       begin() { return data(); }
 		const T* end() const { return data() + _size; }
-		T* end() { return data() + _size; }
+		T*       end() { return data() + _size; }
 		const T& back() const { return end()[-1]; }
-		T& back() { return end()[-1]; }
+		T&       back() { return end()[-1]; }
 
 		const size_t size() const { return _size; }
 		const size_t capacity() const { return _capacity; }
-		T& push() {
-			if constexpr (dynamic) {
-				if (_size == _capacity) { extend(); }
-			} else {
-				inkAssert(_size <= _capacity, "Stack Overflow!");
+		T&           push()
+		{
+			if constexpr ( dynamic )
+			{
+				if ( _size == _capacity )
+				{
+					extend();
+				}
+			}
+			else
+			{
+				inkAssert( _size <= _capacity, "Stack Overflow!" );
 				/// FIXME silent fail!!
 			}
 			return data()[_size++];
 		}
 		void clear() { _size = 0; }
-		void resize(size_t size) {
-			if constexpr (dynamic) {
-				if (size > _capacity) {
-					extend(size);
+		void resize( size_t size )
+		{
+			if constexpr ( dynamic )
+			{
+				if ( size > _capacity )
+				{
+					extend( size );
 				}
-			} else {
-				inkAssert(size <= _size, "Only allow to reduce size");
+			}
+			else
+			{
+				inkAssert( size <= _size, "Only allow to reduce size" );
 			}
 			_size = size;
 		}
 
-		void extend(size_t capacity = 0);
+		void extend( size_t capacity = 0 );
 
-		size_t snap(unsigned char* data, const snapper&) const override
+		size_t snap( unsigned char* data, const snapper& snapper) const 
 		{
-			inkAssert(!is_pointer<T>{}(), "here is a special case oversight");
-			unsigned char* ptr = data;
-			bool should_write = data != nullptr;
-			ptr = snap_write(ptr, _size, should_write );
-			for(const T& e : *this) {
-				ptr = snap_write(ptr, e, should_write );
+			inkAssert( !is_pointer<T>{}(), "here is a special case oversight" );
+			unsigned char* ptr          = data;
+			bool           should_write = data != nullptr;
+			ptr                         = snap_write( ptr, _size, should_write );
+			for ( const T& e : *this )
+			{
+				if constexpr (is_base_of<snapshot_interface, typename remove_cvref<decltype(e)>::type>::value) {
+					ptr += e.snap(data == nullptr ? nullptr : ptr, snapper);
+				} else {
+					ptr = snap_write( ptr, e, should_write );
+				}
 			}
 			return ptr - data;
 		}
-		const unsigned char* snap_load(const unsigned char* ptr, const loader&) override
-{
-			decltype(_size) size;
-			ptr = snap_read(ptr, size);
-			if constexpr (dynamic) {
-				resize(size);
-			} else {
-				inkAssert(size <= initialCapacity, "capacity of non dynamic array is to small vor snapshot!");
+		const unsigned char* snap_load( const unsigned char* ptr, const loader& loader) 
+		{
+			decltype( _size ) size;
+			ptr = snap_read( ptr, size );
+			if constexpr ( dynamic )
+			{
+				resize( size );
 			}
-			for (T& e : *this) {
-				ptr = snap_read(ptr, e);
+			else
+			{
+				inkAssert( size <= initialCapacity, "capacity of non dynamic array is to small vor snapshot!" );
+				_size = size;
+			}
+			for ( T& e : *this )
+			{
+				if constexpr (is_base_of<snapshot_interface, typename remove_cvref<decltype(e)>::type>::value) {
+					ptr = e.snap_load(ptr, loader);
+				} else {
+					ptr = snap_read( ptr, e );
+				}
 			}
 			return ptr;
 		}
-	private:
 
+	private:
 		if_t<dynamic, char, T> _static_data[dynamic ? 1 : initialCapacity];
-		T* _dynamic_data = nullptr;
-		size_t _capacity;
-		size_t _size;
+		T*                     _dynamic_data = nullptr;
+		size_t                 _capacity;
+		size_t                 _size;
 	};
 
 	template<typename T, bool dynamic, size_t initialCapacity>
-	void managed_array<T, dynamic, initialCapacity>::extend(size_t capacity)
+	class managed_restorable_array : public managed_array<T, dynamic, initialCapacity>
 	{
-		static_assert(dynamic, "Can only extend if array is dynamic!");
+		using base = managed_array<T, dynamic, initialCapacity>;
+
+	public:
+		managed_restorable_array()
+		 : base() {}
+		void restore()
+		{
+			base::resize( _last_size );
+		}
+		void save()
+		{
+			_last_size = this->size();
+		}
+		void forgett()
+		{
+			_last_size = 0;
+		}
+		bool has_changed() const
+		{
+			return base::size() != _last_size;
+		}
+
+		size_t snap( unsigned char* data, const base::snapper& snapper ) const
+		{
+			unsigned char* ptr          = data;
+			bool           should_write = data != nullptr;
+			ptr += base::snap( ptr, snapper );
+			ptr = base::snap_write( ptr, _last_size, should_write );
+			return ptr - data;
+		}
+
+		const unsigned char* snap_load(const unsigned char* ptr, const base::loader& loader) {
+			ptr = base::snap_load(ptr, loader);
+			ptr = base::snap_read(ptr, _last_size);
+			return ptr;
+		}
+
+	private:
+		size_t _last_size = 0;
+	};
+
+	template<typename T, bool dynamic, size_t initialCapacity>
+	void managed_array<T, dynamic, initialCapacity>::extend( size_t capacity )
+	{
+		static_assert( dynamic, "Can only extend if array is dynamic!" );
 		size_t new_capacity = capacity > _capacity
-			? capacity
-			: 1.5f * _capacity;
-		if (new_capacity < 5) { new_capacity = 5; }
+		                        ? capacity
+		                        : 1.5f * _capacity;
+		if ( new_capacity < 5 )
+		{
+			new_capacity = 5;
+		}
 		T* new_data = new T[new_capacity];
 
-		for(size_t i = 0; i < _capacity; ++i) {
+		for ( size_t i = 0; i < _capacity; ++i )
+		{
 			new_data[i] = _dynamic_data[i];
 		}
 
 		delete[] _dynamic_data;
 		_dynamic_data = new_data;
-		_capacity = new_capacity;
+		_capacity     = new_capacity;
 	}
 
 	template<typename T>
 	class basic_restorable_array : public snapshot_interface
 	{
 	public:
-		basic_restorable_array(T* array, size_t capacity, T nullValue)
-			: _saved(false), _array(array), _temp(array + capacity/2), _capacity(capacity/2), _null(nullValue)
+		basic_restorable_array( T* array, size_t capacity, T nullValue )
+		 : _saved( false ),
+		   _array( array ),
+		   _temp( array + capacity / 2 ),
+		   _capacity( capacity / 2 ),
+		   _null( nullValue )
 		{
-			inkAssert(capacity % 2 == 0, "basic_restorable_array requires a datablock of even length to split into two arrays");
+			inkAssert( capacity % 2 == 0, "basic_restorable_array requires a datablock of even length to split into two arrays" );
 
 			// zero out main array and put 'nulls' in the clear_temp()
-			inkZeroMemory(_array, _capacity * sizeof(T));
+			inkZeroMemory( _array, _capacity * sizeof( T ) );
 			clear_temp();
 		}
 
 		// == Non-Copyable ==
-		basic_restorable_array(const basic_restorable_array<T>&) = delete;
-		basic_restorable_array<T>& operator=(const basic_restorable_array<T>&) = delete;
+		basic_restorable_array( const basic_restorable_array<T>& )               = delete;
+		basic_restorable_array<T>& operator=( const basic_restorable_array<T>& ) = delete;
 
 		// set value by index
-		void set(size_t index, const T& value);
+		void set( size_t index, const T& value );
 
 		// get value by index
-		const T& get(size_t index) const;
+		const T& get( size_t index ) const;
 
 		// size of the array
 		inline size_t capacity() const { return _capacity; }
 
 		// only const indexing is supported due to save/restore system
-		inline const T& operator[](size_t index) const { return get(index); }
+		inline const T& operator[]( size_t index ) const { return get( index ); }
 
 		// == Save/Restore ==
 		void save();
@@ -151,23 +242,25 @@ namespace ink::runtime::internal
 		void forget();
 
 		// Resets all values and clears any save points
-		void clear(const T& value);
+		void clear( const T& value );
 
 		// snapshot interface
-		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		virtual size_t               snap( unsigned char* data, const snapper& ) const;
+		virtual const unsigned char* snap_load( const unsigned char* data, const loader& );
 
 	protected:
 		inline T* buffer() { return _array; }
-		void set_new_buffer(T* buffer, size_t capacity) {
-			_array = buffer;
-			_temp = buffer + capacity/2;
-			_capacity = capacity/2;
+		void      set_new_buffer( T* buffer, size_t capacity )
+		{
+			_array    = buffer;
+			_temp     = buffer + capacity / 2;
+			_capacity = capacity / 2;
 		}
 
 	private:
-		inline void check_index(size_t index) const { inkAssert(index < capacity(), "Index out of range!"); }
-		void clear_temp();
+		inline void check_index( size_t index ) const { inkAssert( index < capacity(), "Index out of range!" ); }
+		void        clear_temp();
+
 	private:
 		bool _saved;
 
@@ -186,44 +279,46 @@ namespace ink::runtime::internal
 	};
 
 	template<typename T>
-	inline size_t basic_restorable_array<T>::snap(unsigned char* data, const snapper& snapper) const
+	inline size_t basic_restorable_array<T>::snap( unsigned char* data, const snapper& snapper ) const
 	{
-		unsigned char* ptr = data;
-		bool should_write = data != nullptr;
-		ptr = snap_write(ptr, _saved, should_write );
-		ptr = snap_write(ptr, _capacity, should_write );
-		ptr = snap_write(ptr, _null, should_write );
-		for(size_t i = 0; i < _capacity; ++i) {
-			ptr = snap_write(ptr, _array[i], should_write );
-			ptr = snap_write(ptr, _temp[i], should_write );
+		unsigned char* ptr          = data;
+		bool           should_write = data != nullptr;
+		ptr                         = snap_write( ptr, _saved, should_write );
+		ptr                         = snap_write( ptr, _capacity, should_write );
+		ptr                         = snap_write( ptr, _null, should_write );
+		for ( size_t i = 0; i < _capacity; ++i )
+		{
+			ptr = snap_write( ptr, _array[i], should_write );
+			ptr = snap_write( ptr, _temp[i], should_write );
 		}
 		return ptr - data;
 	}
 
 	template<typename T>
-	inline const unsigned char* basic_restorable_array<T>::snap_load(const unsigned char* data, const loader& loader)
+	inline const unsigned char* basic_restorable_array<T>::snap_load( const unsigned char* data, const loader& loader )
 	{
 		auto ptr = data;
-		ptr = snap_read(ptr, _saved);
-		ptr = snap_read(ptr, _capacity);
+		ptr      = snap_read( ptr, _saved );
+		ptr      = snap_read( ptr, _capacity );
 		T null;
-		ptr = snap_read(ptr, null);
-		inkAssert(null == _null, "null value is different to snapshot!");
-		for(size_t i = 0; i < _capacity; ++i) {
-			ptr = snap_read(ptr, _array[i]);
-			ptr = snap_read(ptr, _temp[i]);
+		ptr = snap_read( ptr, null );
+		inkAssert( null == _null, "null value is different to snapshot!" );
+		for ( size_t i = 0; i < _capacity; ++i )
+		{
+			ptr = snap_read( ptr, _array[i] );
+			ptr = snap_read( ptr, _temp[i] );
 		}
 		return ptr;
 	}
 
 	template<typename T>
-	inline void basic_restorable_array<T>::set(size_t index, const T& value)
+	inline void basic_restorable_array<T>::set( size_t index, const T& value )
 	{
-		check_index(index);
-		inkAssert(value != _null, "Can not add a value considered a 'null' to a restorable_array");
+		check_index( index );
+		inkAssert( value != _null, "Can not add a value considered a 'null' to a restorable_array" );
 
 		// If we're saved, store in second half of the array
-		if (_saved)
+		if ( _saved )
 			_temp[index] = value;
 		else
 			// Otherwise, store in the main array
@@ -231,12 +326,12 @@ namespace ink::runtime::internal
 	}
 
 	template<typename T>
-	inline const T& basic_restorable_array<T>::get(size_t index) const
+	inline const T& basic_restorable_array<T>::get( size_t index ) const
 	{
-		check_index(index);
+		check_index( index );
 
 		// If we're in save mode and we have a value at that index, return that instead
-		if (_saved && _temp[index] != _null)
+		if ( _saved && _temp[index] != _null )
 			return _temp[index];
 
 		// Otherwise, fall back on the real array
@@ -263,10 +358,10 @@ namespace ink::runtime::internal
 	inline void basic_restorable_array<T>::forget()
 	{
 		// Run through the _temp array
-		for (size_t i = 0; i < _capacity; i++)
+		for ( size_t i = 0; i < _capacity; i++ )
 		{
 			// Copy if there's values
-			if (_temp[i] != _null)
+			if ( _temp[i] != _null )
 				_array[i] = _temp[i];
 
 			// Clear
@@ -278,7 +373,7 @@ namespace ink::runtime::internal
 	inline void basic_restorable_array<T>::clear_temp()
 	{
 		// Run through the _temp array
-		for (size_t i = 0; i < _capacity; i++)
+		for ( size_t i = 0; i < _capacity; i++ )
 		{
 			// Clear
 			_temp[i] = _null;
@@ -286,12 +381,12 @@ namespace ink::runtime::internal
 	}
 
 	template<typename T>
-	inline void basic_restorable_array<T>::clear(const T& value)
+	inline void basic_restorable_array<T>::clear( const T& value )
 	{
 		_saved = false;
-		for (size_t i = 0; i < _capacity; i++)
+		for ( size_t i = 0; i < _capacity; i++ )
 		{
-			_temp[i] = _null;
+			_temp[i]  = _null;
 			_array[i] = value;
 		}
 	}
@@ -300,9 +395,10 @@ namespace ink::runtime::internal
 	class fixed_restorable_array : public basic_restorable_array<T>
 	{
 	public:
-		fixed_restorable_array(const T& initial, const T &nullValue) : basic_restorable_array<T>(_buffer, SIZE * 2, nullValue) 
-		{ 
-			basic_restorable_array<T>::clear(initial);
+		fixed_restorable_array( const T& initial, const T& nullValue )
+		 : basic_restorable_array<T>( _buffer, SIZE * 2, nullValue )
+		{
+			basic_restorable_array<T>::clear( initial );
 		}
 
 	private:
@@ -313,51 +409,59 @@ namespace ink::runtime::internal
 	class allocated_restorable_array final : public basic_restorable_array<T>
 	{
 		using base = basic_restorable_array<T>;
+
 	public:
-		allocated_restorable_array(const T& initial, const T& nullValue)
-			: basic_restorable_array<T>(0, 0, nullValue), _initialValue{initial}, _nullValue{nullValue},
-				_buffer{nullptr}
+		allocated_restorable_array( const T& initial, const T& nullValue )
+		 : basic_restorable_array<T>( 0, 0, nullValue ),
+		   _initialValue{ initial },
+		   _nullValue{ nullValue },
+		   _buffer{ nullptr }
 		{}
-		allocated_restorable_array(size_t capacity, const T& initial, const T &nullValue)
-			: basic_restorable_array<T>(new T[capacity * 2], capacity * 2, nullValue),
-			_initialValue{initial},
-			_nullValue{nullValue}
+		allocated_restorable_array( size_t capacity, const T& initial, const T& nullValue )
+		 : basic_restorable_array<T>( new T[capacity * 2], capacity * 2, nullValue ),
+		   _initialValue{ initial },
+		   _nullValue{ nullValue }
 		{
 			_buffer = this->buffer();
-			this->clear(_initialValue);
+			this->clear( _initialValue );
 		}
 
-		void resize(size_t n) {
+		void resize( size_t n )
+		{
 			size_t new_capacity = 2 * n;
-			T* new_buffer = new T[new_capacity];
-			if (_buffer) {
-				for(size_t i = 0; i < base::capacity(); ++i) {
+			T*     new_buffer   = new T[new_capacity];
+			if ( _buffer )
+			{
+				for ( size_t i = 0; i < base::capacity(); ++i )
+				{
 					new_buffer[i] = _buffer[i];
 					// copy temp
 					new_buffer[i + base::capacity()] = _buffer[i + base::capacity()];
 				}
 				delete[] _buffer;
 			}
-			for(size_t i = base::capacity(); i < new_capacity; ++i) {
-				new_buffer[i] = _initialValue;
-				new_buffer[i+base::capacity()] = _nullValue;
+			for ( size_t i = base::capacity(); i < new_capacity; ++i )
+			{
+				new_buffer[i]                    = _initialValue;
+				new_buffer[i + base::capacity()] = _nullValue;
 			}
 
 			_buffer = new_buffer;
-			this->set_new_buffer(_buffer, new_capacity);
+			this->set_new_buffer( _buffer, new_capacity );
 		}
 
-		virtual ~allocated_restorable_array() 
+		virtual ~allocated_restorable_array()
 		{
-			if(_buffer) {
+			if ( _buffer )
+			{
 				delete[] _buffer;
 				_buffer = nullptr;
 			}
 		}
 
 	private:
-		T _initialValue;
-		T _nullValue;
+		T  _initialValue;
+		T  _nullValue;
 		T* _buffer;
 	};
-}
+}   // namespace ink::runtime::internal

--- a/inkcpp/collections/restorable.h
+++ b/inkcpp/collections/restorable.h
@@ -333,8 +333,8 @@ namespace ink::runtime::internal
 		}
 
 		// snapshot interface
-		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		virtual size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 	protected:
 		// Called when we run out of space in buffer. 

--- a/inkcpp/globals_impl.h
+++ b/inkcpp/globals_impl.h
@@ -22,8 +22,8 @@ namespace ink::runtime::internal
 	{
 		friend snapshot_impl;
 	public:
-		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
 		// Initializes a new global store from the given story
 		globals_impl(const story_impl*);
 		virtual ~globals_impl() { }

--- a/inkcpp/include/choice.h
+++ b/inkcpp/include/choice.h
@@ -67,7 +67,7 @@ namespace ink
 			uint32_t path() const { return _path; }
 			choice&  setup( internal::basic_stream&, internal::string_table& strings, internal::list_table& lists, int index, uint32_t path, thread_t thread, const char* const* tags );
 
-		private:
+		protected:
 			const char* const* _tags;
 			const char* _text;
 			int _index;

--- a/inkcpp/include/traits.h
+++ b/inkcpp/include/traits.h
@@ -38,6 +38,18 @@ namespace ink::runtime::internal
 	struct false_type : constant<bool, false> {};
 	struct true_type : constant<bool, true>{};
 
+	template<typename B>
+	true_type test_ptr_conv(const volatile B*);
+	template<typename>
+	false_type test_ptr_conv(const volatile void*);
+	template<typename B, typename D>
+	auto test_is_base_of(int) -> decltype(test_ptr_conv<B>(static_cast<D*>(nullptr)));
+	// template<typename, typename> /// FIXME: needed?
+	// auto test_is_base_of(...) -> true_type;
+
+	template<class Base, class Derived>
+	struct is_base_of : constant<bool, decltype(test_is_base_of<Base, Derived>(0))::value> {};
+
 	template<class T, class U>
 	struct is_same : false_type {};
 

--- a/inkcpp/list_table.h
+++ b/inkcpp/list_table.h
@@ -104,8 +104,8 @@ namespace ink::runtime::internal
 		}
 
 		// snapshot interface implementation
-		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 		/** special traitment when a list get assignet again
 		 * when a list get assigned and would have no origin, it gets the origin of the base with origin

--- a/inkcpp/output.cpp
+++ b/inkcpp/output.cpp
@@ -203,16 +203,20 @@ namespace ink::runtime::internal
 		_size = start;
 	}
 
-	bool basic_stream::has_marker() const
+	bool basic_stream::has_marker() const {
+		return entries_since_marker() >= 0;
+	}
+
+	int basic_stream::entries_since_marker() const
 	{
 		// TODO: Cache?
 		for (size_t i = 0; i < _size; i++)
 		{
 			if (_data[i].type() == value_type::marker)
-				return true;
+				return i;
 		}
 
-		return false;
+		return -1;
 	}
 
 	bool basic_stream::ends_with(value_type type) const

--- a/inkcpp/output.h
+++ b/inkcpp/output.h
@@ -64,6 +64,10 @@ namespace ink
 				// Check if the stream has a marker
 				bool has_marker() const;
 
+				// how many entries are behind last marker
+				/// \ratval -1 if no marker is set
+				int entries_since_marker() const;
+
 				// Checks if the stream ends with a specific type
 				bool ends_with(value_type) const;
 

--- a/inkcpp/output.h
+++ b/inkcpp/output.h
@@ -97,8 +97,8 @@ namespace ink
 				bool saved() const { return _save != ~0; }
 
 				// snapshot interface
-				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+				size_t snap(unsigned char* data, const snapper&) const;
+				const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 			private:
 				size_t find_start() const;

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -8,6 +8,7 @@
 #include "snapshot_impl.h"
 #include "system.h"
 #include "value.h"
+#include <iostream>
 
 namespace ink::runtime
 {
@@ -542,13 +543,18 @@ namespace ink::runtime::internal
 		return _globals->create_snapshot();
 	}
 
-	size_t runner_impl::snap(unsigned char* data, const snapper& snapper) const
+	size_t runner_impl::snap(unsigned char* data, snapper& snapper) const
 	{
 		unsigned char* ptr = data;
 		bool should_write = data != nullptr;
-		ptr = snap_write(ptr, _ptr, should_write);
-		ptr = snap_write(ptr, _backup, should_write);
-		ptr = snap_write(ptr, _done, should_write);
+		snapper.current_runner_tags = _tags[0].ptr();
+		std::uintptr_t offset = _ptr != nullptr ? _ptr - _story->instructions() : 0;
+		std::cout << "offset: " << offset << " <-> " << (unsigned long)_ptr << "ptr\n";
+		ptr = snap_write(ptr, offset, should_write);
+		offset = _backup - _story->instructions();
+		ptr = snap_write(ptr, offset, should_write);
+		offset = _done - _story->instructions();
+		ptr = snap_write(ptr, offset, should_write);
 		ptr = snap_write(ptr, _rng.get_state(), should_write);
 		ptr = snap_write(ptr, _evaluation_mode, should_write);
 		ptr = snap_write(ptr, _string_mode, should_write);
@@ -560,43 +566,32 @@ namespace ink::runtime::internal
 		ptr += _ref_stack.snap(data ? ptr : nullptr, snapper);
 		ptr += _eval.snap(data ? ptr : nullptr, snapper);
 		ptr = snap_write(ptr, _choice_tags_begin, should_write);
-		ptr = snap_write(ptr, _tags.size(), should_write);
-		for (const auto& tag : _tags) {
-			std::uintptr_t offset = tag - snapper.story_string_table;
-			ptr = snap_write(ptr, offset, should_write);
-		}
+		ptr += _tags.snap(data ? ptr : nullptr, snapper);
 		ptr += _container.snap(data ? ptr : nullptr, snapper);
 		ptr += _threads.snap(data ? ptr : nullptr, snapper);
-		ptr = snap_write(ptr, _backup_choice_len, should_write);
 		ptr = snap_write(ptr, _fallback_choice.has_value(), should_write);
-		auto snap_choice = [&snapper, &should_write](unsigned char* data, const choice& c) -> size_t {
-			unsigned char* ptr = data;
-			ptr = snap_write(ptr, c._index, should_write );
-			ptr = snap_write(ptr, c._path, should_write );
-			ptr = snap_write(ptr, c._thread, should_write );
-			ptr = snap_write(ptr, snapper.strings.get_id(c._text), should_write );
-			return ptr - data;
-		};
 		if (_fallback_choice) {
-			ptr += snap_choice(ptr, _fallback_choice.value());
+			ptr += _fallback_choice.value().snap(data ? ptr : nullptr, snapper);
 		}
-		ptr = snap_write(ptr, _choices.size(), should_write);
-		for (const choice& c : _choices) {
-			ptr += snap_choice(ptr, c);
-		}
+		ptr += _choices.snap(data ? ptr : nullptr, snapper);
 		return ptr - data;
 	}
 
-	const unsigned char* runner_impl::snap_load(const unsigned char* data, const loader& loader)
+	const unsigned char* runner_impl::snap_load(const unsigned char* data, loader& loader)
 	{
 		auto ptr = data;
-		ptr = snap_read(ptr, _ptr);
-		ptr = snap_read(ptr, _backup);
-		ptr = snap_read(ptr, _done);
+		std::uintptr_t offset;
+		ptr = snap_read(ptr, offset);
+		_ptr = offset == 0 ? nullptr : _story->instructions() + offset;
+		ptr = snap_read(ptr, offset);
+		_backup = _story->instructions() + offset;
+		ptr = snap_read(ptr, offset);
+		_done = _story->instructions() + offset;
 		int32_t seed;
 		ptr = snap_read(ptr, seed);
 		_rng.srand(seed);
 		ptr = snap_read(ptr, _evaluation_mode);
+		ptr = snap_read(ptr, _string_mode);
 		ptr = snap_read(ptr, _saved_evaluation_mode);
 		ptr = snap_read(ptr, _saved);
 		ptr = snap_read(ptr, _is_falling);
@@ -607,37 +602,18 @@ namespace ink::runtime::internal
 		int choice_tags_begin;
 		ptr = snap_read(ptr, choice_tags_begin);
 		_choice_tags_begin = choice_tags_begin;
-		size_t num_tags;
-		ptr = snap_read(ptr, num_tags);
-		for(size_t i = 0; i < num_tags; ++i) {
-			std::uintptr_t offset;
-			ptr = snap_read(ptr, offset);
-			_tags.push() = offset + loader.story_string_table;
-		}
+		ptr = _tags.snap_load(ptr, loader);
+		loader.current_runner_tags = _tags[0].ptr();
 		ptr = _container.snap_load(ptr, loader);
 		ptr = _threads.snap_load(ptr, loader);
-		ptr = snap_read(ptr, _backup_choice_len);
-		auto read_choice = [&ptr,&loader]() -> choice{
-			choice c;
-			ptr = snap_read(ptr, c._index);
-			ptr = snap_read(ptr, c._path);
-			ptr = snap_read(ptr, c._thread);
-			size_t string_id;
-			ptr = snap_read(ptr, string_id);
-			c._text = loader.string_table[string_id];
-			return c;
-		};
 		bool has_fallback_choice;
 		ptr = snap_read(ptr, has_fallback_choice);
-		_fallback_choice = has_fallback_choice
-			? optional<choice>{read_choice()}
-			: nullopt;
-		size_t num_choices;
-		ptr = snap_read(ptr, num_choices);
-		for (size_t i = 0; i < num_choices; ++i) {
-			_choices.push() = read_choice();
+		_fallback_choice = nullopt;
+		if (has_fallback_choice) {
+			_fallback_choice.emplace();
+			ptr = _fallback_choice.value().snap_load(ptr, loader);
 		}
-
+		ptr = _choices.snap_load(ptr, loader);
 		return ptr;
 	}
 
@@ -678,7 +654,7 @@ namespace ink::runtime::internal
 		// Check if the old newline is still present (hasn't been glu'd) and
 		//  if there is new text (non-whitespace) in the stream since saving
 		bool stillHasNewline = _output.saved_ends_with(value_type::newline);
-		bool hasAddedNewText = _output.text_past_save();
+		bool hasAddedNewText = _output.text_past_save() || _tags.has_changed();
 
 		// Newline is still there and there's no new text
 		if (stillHasNewline && !hasAddedNewText)
@@ -1165,7 +1141,7 @@ namespace ink::runtime::internal
 				for(;sc;--sc) { _output << stack[sc-1]; }
 
 				// fetch relevant tags
-				const char* const* tags = nullptr;
+				const snap_tag* tags = nullptr;
 				if (_choice_tags_begin >= 0 && _tags[_tags.size()-1] != nullptr) {
 					for(tags = _tags.end() - 1; *(tags-1) != nullptr && (tags - _tags.begin()) > _choice_tags_begin; --tags);
 					_tags.push() = nullptr;
@@ -1174,9 +1150,9 @@ namespace ink::runtime::internal
 				// Create choice and record it
 				if (flag & CommandFlag::CHOICE_IS_INVISIBLE_DEFAULT) {
 					_fallback_choice
-						= choice{}.setup(_output, _globals->strings(), _globals->lists(), _choices.size(), path, current_thread(), tags);
+						= choice{}.setup(_output, _globals->strings(), _globals->lists(), _choices.size(), path, current_thread(), tags->ptr());
 				} else {
-					add_choice().setup(_output, _globals->strings(), _globals->lists(), _choices.size(), path, current_thread(), tags);
+					add_choice().setup(_output, _globals->strings(), _globals->lists(), _choices.size(), path, current_thread(), tags->ptr());
 				}
 				// save stack at last choice
 				if(_saved) { forget(); }
@@ -1368,7 +1344,8 @@ namespace ink::runtime::internal
 		_globals->save();
 		_eval.save();
 		_threads.save();
-		_backup_choice_len = _choices.size();
+		_choices.save();
+		_tags.save();
 		_saved_evaluation_mode = _evaluation_mode;
 
 		// Not doing this anymore. There can be lingering stack entries from function returns
@@ -1387,7 +1364,8 @@ namespace ink::runtime::internal
 		_globals->restore();
 		_eval.restore();
 		_threads.restore();
-		_choices.resize(_backup_choice_len);
+		_choices.restore();
+		_tags.restore();
 		_evaluation_mode = _saved_evaluation_mode;
 
 		// Not doing this anymore. There can be lingering stack entries from function returns
@@ -1409,6 +1387,8 @@ namespace ink::runtime::internal
 		_globals->forget();
 		_eval.forget();
 		_threads.forget();
+		_choices.forgett();
+		_tags.forgett();
 
 		// Nothing to do for eval stack. It should just stay as it is
 

--- a/inkcpp/runner_impl.cpp
+++ b/inkcpp/runner_impl.cpp
@@ -8,7 +8,6 @@
 #include "snapshot_impl.h"
 #include "system.h"
 #include "value.h"
-#include <iostream>
 
 namespace ink::runtime
 {
@@ -549,7 +548,6 @@ namespace ink::runtime::internal
 		bool should_write = data != nullptr;
 		snapper.current_runner_tags = _tags[0].ptr();
 		std::uintptr_t offset = _ptr != nullptr ? _ptr - _story->instructions() : 0;
-		std::cout << "offset: " << offset << " <-> " << (unsigned long)_ptr << "ptr\n";
 		ptr = snap_write(ptr, offset, should_write);
 		offset = _backup - _story->instructions();
 		ptr = snap_write(ptr, offset, should_write);

--- a/inkcpp/runner_impl.h
+++ b/inkcpp/runner_impl.h
@@ -62,8 +62,8 @@ namespace ink::runtime::internal
 
 		snapshot* create_snapshot() const override;	
 
-		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		size_t snap(unsigned char* data, snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, loader&);
 
 
 #ifdef INK_ENABLE_CSTD
@@ -245,12 +245,11 @@ namespace ink::runtime::internal
 		threads <config::limitContainerDepth < 0, abs( config::limitThreadDepth )> _threads;
 
 		// Choice list
-		managed_array<choice, config::maxChoices < 0, abs(config::maxChoices)> _choices;
-		optional<choice> _fallback_choice;
-		size_t _backup_choice_len = 0;
+		managed_restorable_array<snap_choice, config::maxChoices < 0, abs(config::maxChoices)> _choices;
+		optional<snap_choice> _fallback_choice;
 
 		// Tag list
-		managed_array<const char*, config::limitActiveTags < 0, abs(config::limitActiveTags)> _tags;
+		managed_restorable_array<snap_tag, config::limitActiveTags < 0, abs(config::limitActiveTags)> _tags;
 		int _choice_tags_begin;
 
 		// TODO: Move to story? Both?

--- a/inkcpp/simple_restorable_stack.h
+++ b/inkcpp/simple_restorable_stack.h
@@ -33,8 +33,8 @@ namespace ink::runtime::internal
 		void restore();
 		void forget();
 
-		virtual size_t snap(unsigned char* data, const snapper&) const override;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		virtual size_t snap(unsigned char* data, const snapper&) const;
+		virtual const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 	protected:
 		virtual void overflow(T*& buffer, size_t& size) {

--- a/inkcpp/snapshot_impl.cpp
+++ b/inkcpp/snapshot_impl.cpp
@@ -117,8 +117,14 @@ namespace ink::runtime::internal
 		ptr = snap_write(ptr, _index, should_write);
 		ptr = snap_write(ptr, _path, should_write);
 		ptr = snap_write(ptr, _thread, should_write);
-		std::uintptr_t offset = _tags != nullptr ? _tags - snapper.current_runner_tags : 0;
-		ptr = snap_write(ptr, offset, should_write);
+		// handle difference between no tag and first tag
+		if (_tags == nullptr) {
+			ptr = snap_write(ptr, false, should_write);
+		} else {
+			ptr = snap_write(ptr, true, should_write);
+			std::uintptr_t offset = _tags != nullptr ? _tags - snapper.current_runner_tags : 0;
+			ptr = snap_write(ptr, offset, should_write);
+		}
 		ptr = snap_write(ptr, snapper.strings.get_id(_text), should_write);
 		return ptr - data;
 	}
@@ -128,9 +134,15 @@ namespace ink::runtime::internal
 		ptr = snap_read(ptr, _index);
 		ptr = snap_read(ptr, _path);
 		ptr = snap_read(ptr, _thread);
-		std::uintptr_t offset;
-		ptr = snap_read(ptr, offset);
-		_tags = offset == 0 ? nullptr : loader.current_runner_tags + offset;
+		bool has_tags;
+		ptr = snap_read(ptr, has_tags);
+		if (has_tags) {
+			std::uintptr_t offset;
+			ptr = snap_read(ptr, offset);
+			_tags = loader.current_runner_tags + offset;
+		} else {
+			_tags = nullptr;
+		}
 		size_t string_id;
 		ptr = snap_read(ptr, string_id);
 		_text = loader.string_table[string_id];

--- a/inkcpp/snapshot_impl.cpp
+++ b/inkcpp/snapshot_impl.cpp
@@ -109,4 +109,44 @@ namespace ink::runtime::internal
 		memcpy(&_header, ptr, sizeof(_header));
 		inkAssert(_header.length == _length, "Corrupted file length");
 	}
+
+	
+	size_t snap_choice::snap(unsigned char* data, const snapper& snapper) const{
+		unsigned char* ptr = data;
+		bool should_write = data != nullptr;
+		ptr = snap_write(ptr, _index, should_write);
+		ptr = snap_write(ptr, _path, should_write);
+		ptr = snap_write(ptr, _thread, should_write);
+		std::uintptr_t offset = _tags != nullptr ? _tags - snapper.current_runner_tags : 0;
+		ptr = snap_write(ptr, offset, should_write);
+		ptr = snap_write(ptr, snapper.strings.get_id(_text), should_write);
+		return ptr - data;
+	}
+
+	const unsigned char* snap_choice::snap_load(const unsigned char* data, const loader& loader){
+		const unsigned char* ptr = data;
+		ptr = snap_read(ptr, _index);
+		ptr = snap_read(ptr, _path);
+		ptr = snap_read(ptr, _thread);
+		std::uintptr_t offset;
+		ptr = snap_read(ptr, offset);
+		_tags = offset == 0 ? nullptr : loader.current_runner_tags + offset;
+		size_t string_id;
+		ptr = snap_read(ptr, string_id);
+		_text = loader.string_table[string_id];
+		return ptr;
+	}
+	size_t snap_tag::snap(unsigned char* data, const snapper& snapper) const{
+		std::uintptr_t offset = _str - snapper.story_string_table;
+		unsigned char* ptr = data;
+		ptr = snap_write(ptr, offset, data != nullptr);
+		return ptr - data;
+	}
+	const unsigned char* snap_tag::snap_load(const unsigned char* data, const loader& loader){
+		std::uintptr_t offset;
+		const unsigned char* ptr = data;
+		ptr = snap_read(ptr, offset);
+		_str = loader.story_string_table + offset;
+		return ptr;
+	}
 }

--- a/inkcpp/snapshot_impl.cpp
+++ b/inkcpp/snapshot_impl.cpp
@@ -137,16 +137,28 @@ namespace ink::runtime::internal
 		return ptr;
 	}
 	size_t snap_tag::snap(unsigned char* data, const snapper& snapper) const{
-		std::uintptr_t offset = _str - snapper.story_string_table;
 		unsigned char* ptr = data;
-		ptr = snap_write(ptr, offset, data != nullptr);
+		bool should_write = data != nullptr;
+		if (_str == nullptr) {
+			ptr = snap_write(ptr, false, should_write);
+		} else {
+			size_t id = snapper.strings.get_id(_str);
+			ptr = snap_write(ptr, true, should_write);
+			ptr = snap_write(ptr, id, should_write);
+		}
 		return ptr - data;
 	}
 	const unsigned char* snap_tag::snap_load(const unsigned char* data, const loader& loader){
-		std::uintptr_t offset;
 		const unsigned char* ptr = data;
-		ptr = snap_read(ptr, offset);
-		_str = loader.story_string_table + offset;
+		bool has_content;
+		ptr = snap_read(ptr, has_content);
+		if (!has_content) {
+			_str = nullptr;
+		} else {
+			size_t id;
+			ptr = snap_read(ptr, id);
+			_str = loader.string_table[id];
+		}
 		return ptr;
 	}
 }

--- a/inkcpp/snapshot_interface.h
+++ b/inkcpp/snapshot_interface.h
@@ -38,12 +38,14 @@ namespace ink::runtime::internal
 		struct snapper {
 			const string_table& strings;
 			const char* story_string_table;
+			const char*const* current_runner_tags;
 		};
 		struct loader {
-			managed_array<const char*, true, 5>& string_table;
+			managed_array<const char*, true, 5>& string_table; /// FIXME: make configurable
 			const char* story_string_table;
+			const char*const* current_runner_tags;
 		};
-		virtual size_t snap(unsigned char* data, const snapper&) const = 0;
-		virtual const unsigned char* snap_load(const unsigned char* data, const loader&) = 0;
+		size_t snap(unsigned char* data, snapper&) const { inkFail("Snap function not implemented"); return 0; };
+		const unsigned char* snap_load(const unsigned char* data, loader&) { inkFail("Snap function not implemented"); return nullptr;};
 	};
 }

--- a/inkcpp/stack.h
+++ b/inkcpp/stack.h
@@ -81,8 +81,8 @@ namespace ink
 				void push_values(basic_stack& _stack);
 
 				// snapshot interface
-				size_t snap(unsigned char* data, const snapper&) const override;
-				const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+				size_t snap(unsigned char* data, const snapper&) const;
+				const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 			private:
 				entry& add(hash_t name, const value& val);
@@ -172,9 +172,9 @@ namespace ink
 				void forget();
 
 				// snapshot interface
-				size_t snap(unsigned char* data, const snapper& snapper) const override
+				size_t snap(unsigned char* data, const snapper& snapper) const
 				{ return base::snap(data, snapper); }
-				const unsigned char* snap_load(const unsigned char* data, const loader& loader) override
+				const unsigned char* snap_load(const unsigned char* data, const loader& loader)
 				{ return base::snap_load(data, loader); }
 			};
 

--- a/inkcpp/story_impl.cpp
+++ b/inkcpp/story_impl.cpp
@@ -4,6 +4,7 @@
 #include "globals_impl.h"
 #include "snapshot.h"
 #include "snapshot_impl.h"
+#include "snapshot_interface.h"
 #include "version.h"
 
 #ifdef INK_ENABLE_STL
@@ -222,11 +223,11 @@ namespace ink::runtime::internal
 		if (store == nullptr)
 			store = new_globals_from_snapshot(snapshot);
 		auto* run = new runner_impl(this, store);
-		auto end = run->snap_load(snapshot.get_runner_snap(idx),
-				snapshot_interface::loader{
+		auto loader = snapshot_interface::loader{
 					snapshot.strings(),
 					_string_table, 
-				});
+		};
+		auto end = run->snap_load(snapshot.get_runner_snap(idx), loader);
 		inkAssert(
 			(idx + 1 < snapshot.num_runners() && end == snapshot.get_runner_snap(idx + 1))
 				|| end == snapshot.get_data() + snapshot.get_data_len(), "not all data were used for runner reconstruction"

--- a/inkcpp/string_table.h
+++ b/inkcpp/string_table.h
@@ -24,8 +24,8 @@ namespace ink::runtime::internal
 
 
 		// snapshot interface implementation
-		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 		// get position of string when iterate through data
 		// used to enable storing a string table references

--- a/inkcpp/value.h
+++ b/inkcpp/value.h
@@ -88,8 +88,8 @@ namespace ink::runtime::internal {
 	class value : public snapshot_interface {
 	public:
 		// snapshot interface
-		size_t snap(unsigned char* data, const snapper&) const override;
-		const unsigned char* snap_load(const unsigned char* data, const loader&) override;
+		size_t snap(unsigned char* data, const snapper&) const;
+		const unsigned char* snap_load(const unsigned char* data, const loader&);
 
 		/// help struct to determine cpp type which represent the value_type
 		template<value_type> struct ret { using type = void; };

--- a/unreal/CMakeLists.txt
+++ b/unreal/CMakeLists.txt
@@ -56,4 +56,3 @@ configure_file(
 # Copy files into destination directory
 install(DIRECTORY "inkcpp/" DESTINATION "inkcpp" COMPONENT unreal EXCLUDE_FROM_ALL
 	PATTERN "*.in" EXCLUDE)
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/inkcpp/" DESTINATION "inkcpp" COMPONENT unreal EXCLUDE_FROM_ALL)

--- a/unreal_example.ink
+++ b/unreal_example.ink
@@ -38,11 +38,11 @@ And now some custom background :)
 
 = Color
 Which color do like?
-+ [Magenta]
++ [Magenta # c:mag]
 	A wired choice ... # setColor_255_0_255
-+ [Cyan]
++ [Cyan # c:cya]
 	A think this will be a intense experience. # setColor_0_255_255
-+ [Yellow]
++ [Yellow # c:yel]
 	A delighting decision. # setColor_255_255_0
 - Do You Like your decision?
 + [Yes] ->->


### PR DESCRIPTION
`_tags` in `runner_impl` where not restorable.
Because of this tags of the next line could be printed early
